### PR TITLE
Bump up applications-poc-tools dependencies to 1.5.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,9 +31,10 @@
     <swagger-annotations.version>2.2.23</swagger-annotations.version>
     <openapi-tools.jackson-databind-nullable.version>0.2.6</openapi-tools.jackson-databind-nullable.version>
     <folio-spring-support.version>8.1.2</folio-spring-support.version>
+    <commons-lang3.version>3.17.0</commons-lang3.version>
     <commons-collections4.version>4.4</commons-collections4.version>
     <keycloak.admin.client.version>25.0.4</keycloak.admin.client.version>
-    <applications-poc-tools.version>1.5.5</applications-poc-tools.version>
+    <applications-poc-tools.version>1.5.6</applications-poc-tools.version>
     <aws.version>2.27.17</aws.version>
     <vault.version>5.1.0</vault.version>
 
@@ -89,6 +90,12 @@
       <groupId>org.folio</groupId>
       <artifactId>folio-spring-cql</artifactId>
       <version>${folio-spring-support.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-tls-utils</artifactId>
+      <version>${applications-poc-tools.version}</version>
     </dependency>
 
     <dependency>
@@ -171,12 +178,6 @@
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-collections4</artifactId>
-      <version>${commons-collections4.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/folio/scheduler/integration/keycloak/configuration/KeycloakConfiguration.java
+++ b/src/main/java/org/folio/scheduler/integration/keycloak/configuration/KeycloakConfiguration.java
@@ -3,12 +3,14 @@ package org.folio.scheduler.integration.keycloak.configuration;
 import static jakarta.ws.rs.client.ClientBuilder.newBuilder;
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.stripToNull;
-import static org.apache.http.conn.ssl.NoopHostnameVerifier.INSTANCE;
-import static org.folio.common.utils.FeignClientTlsUtils.buildSslContext;
+import static org.folio.common.utils.tls.FeignClientTlsUtils.buildSslContext;
+import static org.folio.common.utils.tls.Utils.IS_HOSTNAME_VERIFICATION_DISABLED;
 import static org.folio.scheduler.integration.keycloak.utils.KeycloakSecretUtils.globalStoreKey;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.apache.http.conn.ssl.DefaultHostnameVerifier;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.folio.common.configuration.properties.TlsProperties;
 import org.folio.scheduler.integration.keycloak.KeycloakUserImpersonationService;
 import org.folio.scheduler.integration.keycloak.KeycloakUserService;
@@ -29,6 +31,8 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(KeycloakProperties.class)
 @RequiredArgsConstructor
 public class KeycloakConfiguration {
+
+  private static final DefaultHostnameVerifier DEFAULT_HOSTNAME_VERIFIER = new DefaultHostnameVerifier();
 
   private static final String ADMIN_REALM = "master";
   private static final String ADMIN_CLINT_GRANT_TYPE = "client_credentials";
@@ -76,6 +80,9 @@ public class KeycloakConfiguration {
   }
 
   private static ResteasyClient buildResteasyClient(TlsProperties tls) {
-    return (ResteasyClient) newBuilder().sslContext(buildSslContext(tls)).hostnameVerifier(INSTANCE).build();
+    return (ResteasyClient) newBuilder()
+      .sslContext(buildSslContext(tls))
+      .hostnameVerifier(IS_HOSTNAME_VERIFICATION_DISABLED ? NoopHostnameVerifier.INSTANCE : DEFAULT_HOSTNAME_VERIFIER)
+      .build();
   }
 }

--- a/src/test/java/org/folio/scheduler/it/DisableHostnameVerificationConfig.java
+++ b/src/test/java/org/folio/scheduler/it/DisableHostnameVerificationConfig.java
@@ -1,0 +1,13 @@
+package org.folio.scheduler.it;
+
+import static org.apache.commons.lang3.SystemProperties.JDK_INTERNAL_HTTP_CLIENT_DISABLE_HOST_NAME_VERIFICATION;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class DisableHostnameVerificationConfig {
+
+  static {
+    System.setProperty(JDK_INTERNAL_HTTP_CLIENT_DISABLE_HOST_NAME_VERIFICATION, "true");
+  }
+}


### PR DESCRIPTION
## Purpose
Bump up applications-poc-tools dependencies to 1.5.6 to support Hostname Verification for TLS connections
