### PR TITLE
MODSCHED-24 Integrate Internal Route Discovery into Sidecar with Dynamic Routing Switch, Replacing Kong

### DIFF
--- a/src/main/java/org/folio/scheduler/domain/entity/TimerDescriptorEntity.java
+++ b/src/main/java/org/folio/scheduler/domain/entity/TimerDescriptorEntity.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Table;
 import java.util.UUID;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.folio.scheduler.domain.dto.RoutingEntry;
 import org.folio.scheduler.domain.dto.TimerDescriptor;
 import org.hibernate.annotations.Type;
 
@@ -20,6 +21,8 @@ public class TimerDescriptorEntity {
   @Id private UUID id;
 
   private String moduleName;
+
+  private String moduleId;
 
   private String naturalKey;
 
@@ -41,14 +44,13 @@ public class TimerDescriptorEntity {
   }
 
   public static String toNaturalKey(TimerDescriptor timerDescriptor) {
-    if (timerDescriptor.getRoutingEntry() == null) {
+    RoutingEntry re = timerDescriptor.getRoutingEntry();
+    if (re == null) {
       return null;
     }
 
-    var methods = timerDescriptor.getRoutingEntry().getMethods() != null ? String.join(",",
-      timerDescriptor.getRoutingEntry().getMethods()) : "";
-    var path = timerDescriptor.getRoutingEntry().getPath() != null ? timerDescriptor.getRoutingEntry().getPath()
-      : timerDescriptor.getRoutingEntry().getPathPattern();
+    var methods = re.getMethods() != null ? String.join(",", re.getMethods()) : "";
+    var path = re.getPath() != null ? re.getPath() : re.getPathPattern();
     return String.format("%s#%s#%s", timerDescriptor.getModuleName() != null ? timerDescriptor.getModuleName() : "",
       methods, path);
   }

--- a/src/main/java/org/folio/scheduler/domain/entity/TimerDescriptorEntity.java
+++ b/src/main/java/org/folio/scheduler/domain/entity/TimerDescriptorEntity.java
@@ -1,5 +1,7 @@
 package org.folio.scheduler.domain.entity;
 
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
 import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -51,9 +53,12 @@ public class TimerDescriptorEntity {
       return null;
     }
 
+    if (isEmpty(td.getModuleName())) {
+      throw new IllegalArgumentException("Module name is required");
+    }
+
     var methods = re.getMethods() != null ? String.join(",", re.getMethods()) : "";
     var path = re.getPath() != null ? re.getPath() : re.getPathPattern();
-    return String.format("%s#%s#%s#%s", td.getType(), td.getModuleName() != null ? td.getModuleName() : "",
-      methods, path);
+    return String.format("%s#%s#%s#%s", td.getType(), td.getModuleName(), methods, path);
   }
 }

--- a/src/main/java/org/folio/scheduler/domain/entity/TimerDescriptorEntity.java
+++ b/src/main/java/org/folio/scheduler/domain/entity/TimerDescriptorEntity.java
@@ -3,6 +3,8 @@ package org.folio.scheduler.domain.entity;
 import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.util.UUID;
@@ -10,7 +12,10 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.folio.scheduler.domain.dto.RoutingEntry;
 import org.folio.scheduler.domain.dto.TimerDescriptor;
+import org.folio.scheduler.domain.model.TimerType;
+import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.Type;
+import org.hibernate.type.SqlTypes;
 
 @Data
 @Entity
@@ -19,6 +24,11 @@ import org.hibernate.annotations.Type;
 public class TimerDescriptorEntity {
 
   @Id private UUID id;
+
+  @Enumerated(EnumType.STRING)
+  @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+  @Column(name = "type", columnDefinition = "timer_type")
+  private TimerType type;
 
   private String moduleName;
 
@@ -35,23 +45,15 @@ public class TimerDescriptorEntity {
     this.naturalKey = toNaturalKey(timerDescriptor);
   }
 
-  public static TimerDescriptorEntity of(TimerDescriptor timerDescriptor) {
-    var entity = new TimerDescriptorEntity();
-    entity.id = timerDescriptor.getId();
-    entity.timerDescriptor = timerDescriptor;
-    entity.naturalKey = toNaturalKey(timerDescriptor);
-    return entity;
-  }
-
-  public static String toNaturalKey(TimerDescriptor timerDescriptor) {
-    RoutingEntry re = timerDescriptor.getRoutingEntry();
+  public static String toNaturalKey(TimerDescriptor td) {
+    RoutingEntry re = td.getRoutingEntry();
     if (re == null) {
       return null;
     }
 
     var methods = re.getMethods() != null ? String.join(",", re.getMethods()) : "";
     var path = re.getPath() != null ? re.getPath() : re.getPathPattern();
-    return String.format("%s#%s#%s", timerDescriptor.getModuleName() != null ? timerDescriptor.getModuleName() : "",
+    return String.format("%s#%s#%s#%s", td.getType(), td.getModuleName() != null ? td.getModuleName() : "",
       methods, path);
   }
 }

--- a/src/main/java/org/folio/scheduler/domain/model/TimerType.java
+++ b/src/main/java/org/folio/scheduler/domain/model/TimerType.java
@@ -1,0 +1,6 @@
+package org.folio.scheduler.domain.model;
+
+public enum TimerType {
+  USER,
+  SYSTEM
+}

--- a/src/main/java/org/folio/scheduler/integration/OkapiClient.java
+++ b/src/main/java/org/folio/scheduler/integration/OkapiClient.java
@@ -8,9 +8,12 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 @FeignClient(name = "okapi")
 public interface OkapiClient {
+
+  String MODULE_HINT = "x-okapi-module-hint";
 
   /**
    * Performs GET HTTP Request.
@@ -18,7 +21,7 @@ public interface OkapiClient {
    * @param uri - uniform resource identifier
    */
   @GetMapping(consumes = APPLICATION_JSON_VALUE)
-  void doGet(URI uri);
+  void doGet(URI uri, @RequestHeader(MODULE_HINT) String moduleHint);
 
   /**
    * Performs POST HTTP Request.
@@ -26,7 +29,7 @@ public interface OkapiClient {
    * @param uri - uniform resource identifier
    */
   @PostMapping(consumes = APPLICATION_JSON_VALUE)
-  void doPost(URI uri);
+  void doPost(URI uri, @RequestHeader(MODULE_HINT) String moduleHint);
 
   /**
    * Performs PUT HTTP Request.
@@ -34,7 +37,7 @@ public interface OkapiClient {
    * @param uri - uniform resource identifier
    */
   @PutMapping(consumes = APPLICATION_JSON_VALUE)
-  void doPut(URI uri);
+  void doPut(URI uri, @RequestHeader(MODULE_HINT) String moduleHint);
 
   /**
    * Performs DELETE HTTP Request.
@@ -42,5 +45,5 @@ public interface OkapiClient {
    * @param uri - uniform resource identifier
    */
   @DeleteMapping(consumes = APPLICATION_JSON_VALUE)
-  void doDelete(URI uri);
+  void doDelete(URI uri, @RequestHeader(MODULE_HINT) String moduleHint);
 }

--- a/src/main/java/org/folio/scheduler/mapper/TimerDescriptorMapper.java
+++ b/src/main/java/org/folio/scheduler/mapper/TimerDescriptorMapper.java
@@ -1,5 +1,8 @@
 package org.folio.scheduler.mapper;
 
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
+import org.folio.common.utils.SemverUtils;
 import org.folio.scheduler.domain.dto.TimerDescriptor;
 import org.folio.scheduler.domain.entity.TimerDescriptorEntity;
 import org.mapstruct.Mapper;
@@ -23,5 +26,11 @@ public interface TimerDescriptorMapper {
    * @return converted {@link TimerDescriptorEntity} object
    */
   @Mapping(target = "timerDescriptor", source = "descriptor")
+  @Mapping(target = "moduleName", expression = "java(fromModuleId(descriptor))")
   TimerDescriptorEntity convert(TimerDescriptor descriptor);
+
+  default String fromModuleId(TimerDescriptor descriptor) {
+    var moduleId = descriptor.getModuleId();
+    return isNotEmpty(moduleId) ? SemverUtils.getName(moduleId) : descriptor.getModuleName();
+  }
 }

--- a/src/main/java/org/folio/scheduler/mapper/TimerDescriptorMapper.java
+++ b/src/main/java/org/folio/scheduler/mapper/TimerDescriptorMapper.java
@@ -12,19 +12,12 @@ import org.mapstruct.Mapping;
 public interface TimerDescriptorMapper {
 
   /**
-   * Converts {@link TimerDescriptorEntity} to {@link TimerDescriptor} object.
-   *
-   * @param entity - {@link TimerDescriptorEntity} object
-   * @return converted {@link TimerDescriptor} object
-   */
-  TimerDescriptor convert(TimerDescriptorEntity entity);
-
-  /**
    * Converts {@link TimerDescriptor} to {@link TimerDescriptorEntity} object.
    *
    * @param descriptor - {@link TimerDescriptor} object
    * @return converted {@link TimerDescriptorEntity} object
    */
+  @Mapping(target = "naturalKey", ignore = true)
   @Mapping(target = "timerDescriptor", source = "descriptor")
   @Mapping(target = "moduleName", expression = "java(fromModuleId(descriptor))")
   TimerDescriptorEntity convert(TimerDescriptor descriptor);

--- a/src/main/java/org/folio/scheduler/mapper/TimerDescriptorMapper.java
+++ b/src/main/java/org/folio/scheduler/mapper/TimerDescriptorMapper.java
@@ -1,8 +1,5 @@
 package org.folio.scheduler.mapper;
 
-import static org.apache.commons.lang3.StringUtils.isNotEmpty;
-
-import org.folio.common.utils.SemverUtils;
 import org.folio.scheduler.domain.dto.TimerDescriptor;
 import org.folio.scheduler.domain.entity.TimerDescriptorEntity;
 import org.mapstruct.Mapper;
@@ -19,11 +16,5 @@ public interface TimerDescriptorMapper {
    */
   @Mapping(target = "naturalKey", ignore = true)
   @Mapping(target = "timerDescriptor", source = "descriptor")
-  @Mapping(target = "moduleName", expression = "java(fromModuleId(descriptor))")
   TimerDescriptorEntity convert(TimerDescriptor descriptor);
-
-  default String fromModuleId(TimerDescriptor descriptor) {
-    var moduleId = descriptor.getModuleId();
-    return isNotEmpty(moduleId) ? SemverUtils.getName(moduleId) : descriptor.getModuleName();
-  }
 }

--- a/src/main/java/org/folio/scheduler/repository/SchedulerTimerRepository.java
+++ b/src/main/java/org/folio/scheduler/repository/SchedulerTimerRepository.java
@@ -4,13 +4,14 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.folio.scheduler.domain.entity.TimerDescriptorEntity;
+import org.folio.scheduler.domain.model.TimerType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SchedulerTimerRepository extends JpaRepository<TimerDescriptorEntity, UUID> {
 
-  List<TimerDescriptorEntity> findByModuleName(String moduleName);
+  List<TimerDescriptorEntity> findByModuleNameAndType(String moduleName, TimerType type);
 
   Optional<TimerDescriptorEntity> findByNaturalKey(String naturalKey);
 }

--- a/src/main/java/org/folio/scheduler/service/SchedulerTimerService.java
+++ b/src/main/java/org/folio/scheduler/service/SchedulerTimerService.java
@@ -15,6 +15,7 @@ import lombok.extern.log4j.Log4j2;
 import org.folio.scheduler.domain.dto.TimerDescriptor;
 import org.folio.scheduler.domain.entity.TimerDescriptorEntity;
 import org.folio.scheduler.domain.model.SearchResult;
+import org.folio.scheduler.domain.model.TimerType;
 import org.folio.scheduler.exception.RequestValidationException;
 import org.folio.scheduler.mapper.TimerDescriptorMapper;
 import org.folio.scheduler.repository.SchedulerTimerRepository;
@@ -43,8 +44,9 @@ public class SchedulerTimerService {
   }
 
   @Transactional(readOnly = true)
-  public List<TimerDescriptor> findByModuleName(String moduleName) {
-    return mapItems(schedulerTimerRepository.findByModuleName(moduleName), TimerDescriptorEntity::getTimerDescriptor);
+  public List<TimerDescriptor> findByModuleNameAndType(String moduleName, TimerType type) {
+    return mapItems(schedulerTimerRepository.findByModuleNameAndType(moduleName, type),
+      TimerDescriptorEntity::getTimerDescriptor);
   }
 
   /**
@@ -155,6 +157,10 @@ public class SchedulerTimerService {
 
     if (isEmpty(timerDescriptor.getModuleId()) && isEmpty(timerDescriptor.getModuleName())) {
       throw new IllegalArgumentException("Module id or module name is required");
+    }
+
+    if (timerDescriptor.getType() == null) {
+      throw new IllegalArgumentException("Timer type is required");
     }
   }
 

--- a/src/main/java/org/folio/scheduler/service/SchedulerTimerService.java
+++ b/src/main/java/org/folio/scheduler/service/SchedulerTimerService.java
@@ -1,6 +1,7 @@
 package org.folio.scheduler.service;
 
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.folio.common.utils.CollectionUtils.mapItems;
 
 import jakarta.persistence.EntityExistsException;
@@ -150,6 +151,10 @@ public class SchedulerTimerService {
     if (timerDescriptor.getRoutingEntry().getMethods() != null
       && timerDescriptor.getRoutingEntry().getMethods().size() > 1) {
       throw new IllegalArgumentException("Only 1 method is allowed per timer");
+    }
+
+    if (isEmpty(timerDescriptor.getModuleId()) && isEmpty(timerDescriptor.getModuleName())) {
+      throw new IllegalArgumentException("Module id or module name is required");
     }
   }
 

--- a/src/main/java/org/folio/scheduler/service/SchedulerTimerService.java
+++ b/src/main/java/org/folio/scheduler/service/SchedulerTimerService.java
@@ -3,6 +3,7 @@ package org.folio.scheduler.service;
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.folio.common.utils.CollectionUtils.mapItems;
+import static org.folio.scheduler.utils.TimerDescriptorUtils.evalModuleName;
 
 import jakarta.persistence.EntityExistsException;
 import jakarta.persistence.EntityNotFoundException;
@@ -92,6 +93,8 @@ public class SchedulerTimerService {
     validate(timerDescriptor);
 
     timerDescriptor.setId(defaultIfNull(id, UUID.randomUUID()));
+    timerDescriptor.setModuleName(evalModuleName(timerDescriptor));
+
     var naturalKey = TimerDescriptorEntity.toNaturalKey(timerDescriptor);
     return schedulerTimerRepository.findByNaturalKey(naturalKey)
       .map(existingTimer -> {
@@ -120,6 +123,7 @@ public class SchedulerTimerService {
     }
 
     validate(newDescriptor);
+    newDescriptor.setModuleName(evalModuleName(newDescriptor));
 
     return doUpdate(newDescriptor);
   }

--- a/src/main/java/org/folio/scheduler/service/jobs/OkapiHttpRequestExecutor.java
+++ b/src/main/java/org/folio/scheduler/service/jobs/OkapiHttpRequestExecutor.java
@@ -116,9 +116,11 @@ public class OkapiHttpRequestExecutor implements Job {
   }
 
   private static String moduleHint(TimerDescriptor td) {
-    return td.getType() == TimerType.USER
-      ? td.getModuleName()
-      : StringUtils.isNotEmpty(td.getModuleId()) ? td.getModuleId() : td.getModuleName();
+    return td.getType() == TimerType.USER ? td.getModuleName() : moduleIdOrName(td);
+  }
+
+  private static String moduleIdOrName(TimerDescriptor td) {
+    return StringUtils.isNotEmpty(td.getModuleId()) ? td.getModuleId() : td.getModuleName();
   }
 
   private static String getStaticPath(RoutingEntry re) {

--- a/src/main/java/org/folio/scheduler/service/jobs/OkapiHttpRequestExecutor.java
+++ b/src/main/java/org/folio/scheduler/service/jobs/OkapiHttpRequestExecutor.java
@@ -8,7 +8,6 @@ import static java.util.Collections.singletonList;
 import static java.util.Map.entry;
 import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
-import static org.folio.spring.integration.XOkapiHeaders.MODULE_ID;
 import static org.folio.spring.integration.XOkapiHeaders.REQUEST_ID;
 import static org.folio.spring.integration.XOkapiHeaders.TENANT;
 import static org.folio.spring.integration.XOkapiHeaders.TOKEN;
@@ -23,7 +22,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.scheduler.configuration.properties.OkapiConfigurationProperties;
@@ -46,7 +45,7 @@ public class OkapiHttpRequestExecutor implements Job {
   private final FolioModuleMetadata folioModuleMetadata;
   private final SchedulerTimerService schedulerTimerService;
   private final OkapiConfigurationProperties okapiConfigurationProperties;
-  private final Map<HttpMethod, Consumer<URI>> okapiCallMap;
+  private final Map<HttpMethod, BiConsumer<URI, String>> okapiCallMap;
   private final UserImpersonationService userImpersonationService;
 
   /**
@@ -105,12 +104,18 @@ public class OkapiHttpRequestExecutor implements Job {
     }
 
     var staticPath = getStaticPath(re);
-    log.info("Calling specified HTTP method [timerId: {}, method: {}, path: {}]", timerId, httpMethod, staticPath);
+    var moduleHint = moduleHint(timerDescriptor);
+    log.info("Calling specified HTTP method [timerId: {}, method: {}, path: {}, moduleHint: {}]",
+      timerId, httpMethod, staticPath, moduleHint);
     try {
-      okapiCallExecutor.accept(fromUriString("http:/" + staticPath).build().toUri());
+      okapiCallExecutor.accept(fromUriString("http:/" + staticPath).build().toUri(), moduleHint);
     } catch (FeignException e) {
       log.warn("Failed to perform HTTP request [id: {}, method: {}, path: /{}]", timerId, httpMethod, staticPath, e);
     }
+  }
+
+  private static String moduleHint(TimerDescriptor td) {
+    return StringUtils.isNotEmpty(td.getModuleId()) ? td.getModuleId() : td.getModuleName();
   }
 
   private static String getStaticPath(RoutingEntry re) {
@@ -125,7 +130,6 @@ public class OkapiHttpRequestExecutor implements Job {
     headers.put(URL, singletonList(okapiConfigurationProperties.getUrl()));
     headers.put(TOKEN, singletonList(userImpersonationService.impersonate(tenant, userId)));
     headers.put(REQUEST_ID, singletonList(String.format("%06d", current().nextInt(1000000))));
-    headers.put(MODULE_ID, singletonList(folioModuleMetadata.getModuleName()));
     headers.put(TENANT, singletonList(tenant));
     return headers;
   }

--- a/src/main/java/org/folio/scheduler/service/jobs/OkapiHttpRequestExecutor.java
+++ b/src/main/java/org/folio/scheduler/service/jobs/OkapiHttpRequestExecutor.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.folio.scheduler.configuration.properties.OkapiConfigurationProperties;
 import org.folio.scheduler.domain.dto.RoutingEntry;
 import org.folio.scheduler.domain.dto.TimerDescriptor;
+import org.folio.scheduler.domain.dto.TimerType;
 import org.folio.scheduler.integration.OkapiClient;
 import org.folio.scheduler.service.SchedulerTimerService;
 import org.folio.scheduler.service.UserImpersonationService;
@@ -115,7 +116,9 @@ public class OkapiHttpRequestExecutor implements Job {
   }
 
   private static String moduleHint(TimerDescriptor td) {
-    return StringUtils.isNotEmpty(td.getModuleId()) ? td.getModuleId() : td.getModuleName();
+    return td.getType() == TimerType.USER
+      ? td.getModuleName()
+      : StringUtils.isNotEmpty(td.getModuleId()) ? td.getModuleId() : td.getModuleName();
   }
 
   private static String getStaticPath(RoutingEntry re) {

--- a/src/main/java/org/folio/scheduler/utils/TimerDescriptorUtils.java
+++ b/src/main/java/org/folio/scheduler/utils/TimerDescriptorUtils.java
@@ -1,0 +1,16 @@
+package org.folio.scheduler.utils;
+
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
+import lombok.experimental.UtilityClass;
+import org.folio.common.utils.SemverUtils;
+import org.folio.scheduler.domain.dto.TimerDescriptor;
+
+@UtilityClass
+public class TimerDescriptorUtils {
+
+  public static String evalModuleName(TimerDescriptor td) {
+    var moduleId = td.getModuleId();
+    return isNotEmpty(moduleId) ? SemverUtils.getName(moduleId) : td.getModuleName();
+  }
+}

--- a/src/main/resources/changelog/changelog-master.xml
+++ b/src/main/resources/changelog/changelog-master.xml
@@ -10,4 +10,5 @@
   <include file="changes/03_add_natural_key_column_to_timer.xml" relativeToChangelogFile="true"/>
   <include file="changes/04_split_timers_by_method.xml" relativeToChangelogFile="true"/>
   <include file="changes/05_populate_natural_key_and_deduplicate.xml" relativeToChangelogFile="true"/>
+  <include file="changes/06_add_module_id_column_to_timer.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changelog/changelog-master.xml
+++ b/src/main/resources/changelog/changelog-master.xml
@@ -11,4 +11,5 @@
   <include file="changes/04_split_timers_by_method.xml" relativeToChangelogFile="true"/>
   <include file="changes/05_populate_natural_key_and_deduplicate.xml" relativeToChangelogFile="true"/>
   <include file="changes/06_add_module_id_column_to_timer.xml" relativeToChangelogFile="true"/>
+  <include file="changes/07_add_type_column_to_timer.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changelog/changes/06_add_module_id_column_to_timer.xml
+++ b/src/main/resources/changelog/changes/06_add_module_id_column_to_timer.xml
@@ -1,0 +1,17 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
+  <changeSet id="add-module-id-to-timer" author="dmtkachenko">
+    <addColumn tableName="timer">
+      <column name="module_id" type="varchar(256)"/>
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="create-index-module-id" author="dmtkachenko">
+    <createIndex indexName="idx_module_id" tableName="timer">
+      <column name="module_id"/>
+    </createIndex>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/changelog/changes/07_add_type_column_to_timer.xml
+++ b/src/main/resources/changelog/changes/07_add_type_column_to_timer.xml
@@ -1,0 +1,33 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
+  <changeSet id="create-timer-type-enum" author="dmtkachenko">
+    <sql>
+      CREATE TYPE timer_type AS ENUM ('USER', 'SYSTEM');
+    </sql>
+  </changeSet>
+
+  <changeSet id="add-timer-type-to-timer" author="dmtkachenko">
+    <addColumn tableName="timer">
+      <column name="type" type="timer_type" defaultValue="USER">
+        <constraints nullable="false"/>
+      </column>
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="update-type-natural-key-in-timers" author="dmtkachenko">
+    <update tableName="timer">
+      <column name="type" value="SYSTEM"/>
+      <column name="natural_key" valueComputed="CONCAT('SYSTEM', '#', natural_key)"/>
+      <where>module_name IS NOT NULL AND natural_key NOT LIKE 'SYSTEM%'</where>
+    </update>
+
+    <update tableName="timer">
+      <column name="type" value="USER"/>
+      <column name="natural_key" valueComputed="CONCAT('USER', '#', natural_key)"/>
+      <where>module_name IS NULL AND natural_key NOT LIKE 'USER%'</where>
+    </update>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/changelog/changes/07_add_type_column_to_timer.xml
+++ b/src/main/resources/changelog/changes/07_add_type_column_to_timer.xml
@@ -30,4 +30,18 @@
       <where>module_name IS NULL AND natural_key NOT LIKE 'USER%'</where>
     </update>
   </changeSet>
+
+  <changeSet id="update-type-in-timer-descriptors" author="dmtkachenko">
+    <sql>
+      -- Update 'type' attribute in timer_descriptor jsonb column for those records where 'type' is not null
+      -- Set 'type' attribute to "user" if type is 'USER' and to "system" if type is 'SYSTEM'
+      UPDATE timer
+        SET timer_descriptor = jsonb_set(timer_descriptor, '{type}', to_jsonb(CASE
+            WHEN type = 'USER' THEN 'user'
+            WHEN type = 'SYSTEM' THEN 'system'
+            ELSE NULL
+        END))
+        WHERE type IS NOT NULL;
+    </sql>
+  </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/swagger.api/schemas/timerDescriptor.json
+++ b/src/main/resources/swagger.api/schemas/timerDescriptor.json
@@ -22,7 +22,11 @@
       "type": "boolean"
     },
     "moduleName": {
-      "description": "Module name timer belongs to",
+      "description": "Module name timer belongs to (module id should be used instead)",
+      "type": "string"
+    },
+    "moduleId": {
+      "description": "Module id timer belongs to (if present module name is not needed)",
       "type": "string"
     }
   },

--- a/src/main/resources/swagger.api/schemas/timerDescriptor.json
+++ b/src/main/resources/swagger.api/schemas/timerDescriptor.json
@@ -9,6 +9,10 @@
       "type": "string",
       "format": "uuid"
     },
+    "type": {
+      "$ref": "timerType.json",
+      "description": "Timer type"
+    },
     "modified": {
       "description": "Whether modified",
       "type": "boolean"

--- a/src/main/resources/swagger.api/schemas/timerType.json
+++ b/src/main/resources/swagger.api/schemas/timerType.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "timerType.json",
+  "title": "Timer Type Schema",
+  "description": "Timer type",
+  "default": "user",
+  "type": "string",
+  "enum": [ "user", "system" ],
+  "x-enum-varnames": [ "USER", "SYSTEM" ]
+}

--- a/src/test/java/org/folio/scheduler/integration/kafka/KafkaMessageListenerTest.java
+++ b/src/test/java/org/folio/scheduler/integration/kafka/KafkaMessageListenerTest.java
@@ -36,6 +36,8 @@ class KafkaMessageListenerTest {
   private static final String SYSTEM_USER_ID = UUID.randomUUID().toString();
   private static final UUID TIMER_ID = UUID.randomUUID();
   private static final String MODULE_NAME = "mod-foo";
+  private static final String MODULE_ID1 = "mod-foo-1.0.0";
+  private static final String MODULE_ID2 = "mod-foo-1.0.1";
 
   @InjectMocks private KafkaMessageListener kafkaMessageListener;
   @Mock private SystemUserService systemUserService;
@@ -55,7 +57,7 @@ class KafkaMessageListenerTest {
     kafkaMessageListener.handleScheduledJobEvent(consumerRecord);
 
     verify(schedulerTimerService).create(
-      new TimerDescriptor().enabled(true).moduleName(MODULE_NAME).routingEntry(routingEntry1()));
+      new TimerDescriptor().enabled(true).moduleName(MODULE_NAME).moduleId(MODULE_ID1).routingEntry(routingEntry1()));
   }
 
   @Test
@@ -70,7 +72,7 @@ class KafkaMessageListenerTest {
     verify(schedulerTimerService).delete(TIMER_ID);
     verify(schedulerTimerService).findByModuleName(MODULE_NAME);
     verify(schedulerTimerService).create(
-      new TimerDescriptor().enabled(true).moduleName(MODULE_NAME).routingEntry(routingEntry2()));
+      new TimerDescriptor().enabled(true).moduleName(MODULE_NAME).moduleId(MODULE_ID2).routingEntry(routingEntry2()));
   }
 
   @Test
@@ -89,7 +91,8 @@ class KafkaMessageListenerTest {
   @Test
   void handleScheduledJobEvent_negative() {
     when(systemUserService.findSystemUserId(TENANT_ID)).thenReturn(SYSTEM_USER_ID);
-    var expectedDescriptor = new TimerDescriptor().enabled(true).moduleName(MODULE_NAME).routingEntry(routingEntry1());
+    var expectedDescriptor = new TimerDescriptor().enabled(true)
+      .moduleName(MODULE_NAME).moduleId(MODULE_ID1).routingEntry(routingEntry1());
     when(schedulerTimerService.create(expectedDescriptor)).thenThrow(RuntimeException.class);
 
     var consumerRec = new ConsumerRecord<>(TOPIC_NAME, 0, 0, TENANT_ID, createResourceEvent());
@@ -126,14 +129,14 @@ class KafkaMessageListenerTest {
 
   private static ScheduledTimers scheduledTimersBeforeUpgrade() {
     return new ScheduledTimers()
-      .moduleId("mod-foo-1.0.0")
+      .moduleId(MODULE_ID1)
       .applicationId("app-foo-1.0.0")
       .timers(List.of(routingEntry1()));
   }
 
   private static ScheduledTimers scheduledTimersAfterUpgrade() {
     return new ScheduledTimers()
-      .moduleId("mod-foo-1.0.1")
+      .moduleId(MODULE_ID2)
       .applicationId("app-foo-1.0.1")
       .timers(List.of(routingEntry2()));
   }

--- a/src/test/java/org/folio/scheduler/integration/kafka/KafkaMessageListenerTest.java
+++ b/src/test/java/org/folio/scheduler/integration/kafka/KafkaMessageListenerTest.java
@@ -2,6 +2,7 @@ package org.folio.scheduler.integration.kafka;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.folio.scheduler.domain.dto.TimerUnit.MINUTE;
+import static org.folio.scheduler.domain.model.TimerType.SYSTEM;
 import static org.folio.scheduler.integration.kafka.model.ResourceEventType.CREATE;
 import static org.folio.scheduler.integration.kafka.model.ResourceEventType.DELETE;
 import static org.folio.scheduler.integration.kafka.model.ResourceEventType.UPDATE;
@@ -63,14 +64,14 @@ class KafkaMessageListenerTest {
   @Test
   void handleScheduledJobEvent_positive_update() {
     when(systemUserService.findSystemUserId(TENANT_ID)).thenReturn(SYSTEM_USER_ID);
-    when(schedulerTimerService.findByModuleName(MODULE_NAME)).thenReturn(
+    when(schedulerTimerService.findByModuleNameAndType(MODULE_NAME, SYSTEM)).thenReturn(
       List.of(new TimerDescriptor().id(TIMER_ID).enabled(true).routingEntry(routingEntry1())));
 
     var consumerRec = new ConsumerRecord<>(TOPIC_NAME, 0, 0, TENANT_ID, udpateResourceEvent());
     kafkaMessageListener.handleScheduledJobEvent(consumerRec);
 
     verify(schedulerTimerService).delete(TIMER_ID);
-    verify(schedulerTimerService).findByModuleName(MODULE_NAME);
+    verify(schedulerTimerService).findByModuleNameAndType(MODULE_NAME, SYSTEM);
     verify(schedulerTimerService).create(
       new TimerDescriptor().enabled(true).moduleName(MODULE_NAME).moduleId(MODULE_ID2).routingEntry(routingEntry2()));
   }
@@ -78,14 +79,14 @@ class KafkaMessageListenerTest {
   @Test
   void handleScheduledJobEvent_positive_delete() {
     when(systemUserService.findSystemUserId(TENANT_ID)).thenReturn(SYSTEM_USER_ID);
-    when(schedulerTimerService.findByModuleName(MODULE_NAME)).thenReturn(
+    when(schedulerTimerService.findByModuleNameAndType(MODULE_NAME, SYSTEM)).thenReturn(
       List.of(new TimerDescriptor().id(TIMER_ID).enabled(true).routingEntry(routingEntry1())));
 
     var consumerRec = new ConsumerRecord<>(TOPIC_NAME, 0, 0, TENANT_ID, deleteResourceEvent());
     kafkaMessageListener.handleScheduledJobEvent(consumerRec);
 
     verify(schedulerTimerService).delete(TIMER_ID);
-    verify(schedulerTimerService).findByModuleName(MODULE_NAME);
+    verify(schedulerTimerService).findByModuleNameAndType(MODULE_NAME, SYSTEM);
   }
 
   @Test

--- a/src/test/java/org/folio/scheduler/it/SchedulerTimerIT.java
+++ b/src/test/java/org/folio/scheduler/it/SchedulerTimerIT.java
@@ -83,7 +83,7 @@ class SchedulerTimerIT extends BaseIntegrationTest {
   }
 
   @Test
-  @WireMockStub("/wiremock/stubs/timer-endpoint.json")
+  @WireMockStub("/wiremock/stubs/user-timer-endpoint.json")
   @KeycloakRealms("/json/keycloak/test-realm.json")
   void create_positive_simpleTrigger() throws Exception {
     var timerId = UUID.randomUUID();
@@ -110,7 +110,7 @@ class SchedulerTimerIT extends BaseIntegrationTest {
   }
 
   @Test
-  @WireMockStub("/wiremock/stubs/timer-endpoint.json")
+  @WireMockStub("/wiremock/stubs/user-timer-endpoint.json")
   @KeycloakRealms("/json/keycloak/test-realm.json")
   void create_positive_cronTrigger() throws Exception {
     var timerId = UUID.randomUUID().toString();

--- a/src/test/java/org/folio/scheduler/it/SchedulerTimerIT.java
+++ b/src/test/java/org/folio/scheduler/it/SchedulerTimerIT.java
@@ -48,6 +48,7 @@ class SchedulerTimerIT extends BaseIntegrationTest {
   private static final String UNKNOWN_ID = "51fd5dff-5d51-4169-a296-d441e1d234c9";
   private static final UUID TIMER_ID_TO_UPDATE = UUID.fromString("123e4567-e89b-12d3-a456-426614174001");
   private static final String TIMER_ID_TO_DELETE = "123e4567-e89b-12d3-a456-426614174002";
+  private static final String MODULE_ID = "mod-foo-1.0.0";
 
   @Autowired private Scheduler scheduler;
   @Autowired private ObjectMapper objectMapper;
@@ -89,6 +90,7 @@ class SchedulerTimerIT extends BaseIntegrationTest {
     var timerDescriptor = new TimerDescriptor()
       .id(timerId)
       .enabled(true)
+      .moduleId(MODULE_ID)
       .routingEntry(new RoutingEntry()
         .methods(List.of("POST"))
         .pathPattern("/test")
@@ -115,6 +117,7 @@ class SchedulerTimerIT extends BaseIntegrationTest {
     var timerDescriptor = new TimerDescriptor()
       .id(UUID.fromString(timerId))
       .enabled(true)
+      .moduleId(MODULE_ID)
       .routingEntry(new RoutingEntry()
         .methods(List.of("POST"))
         .pathPattern("/test")
@@ -134,7 +137,7 @@ class SchedulerTimerIT extends BaseIntegrationTest {
 
   @Test
   void update_positive() throws Exception {
-    var desc = TestValues.timerDescriptor(TIMER_ID_TO_UPDATE);
+    var desc = TestValues.timerDescriptor(TIMER_ID_TO_UPDATE).moduleId(MODULE_ID);
     doPut("/scheduler/timers/{id}", desc, TIMER_ID_TO_UPDATE)
       .andExpect(jsonPath("$.id", notNullValue()))
       .andExpect(jsonPath("$.enabled", is(true)));
@@ -160,6 +163,7 @@ class SchedulerTimerIT extends BaseIntegrationTest {
   void create_duplicate() throws Exception {
     var timerDescriptor = new TimerDescriptor()
       .enabled(true)
+      .moduleId(MODULE_ID)
       .routingEntry(new RoutingEntry()
         .methods(List.of("POST"))
         .pathPattern("/test/sometimer")

--- a/src/test/java/org/folio/scheduler/migration/SplitTimersByMethodMigrationTest.java
+++ b/src/test/java/org/folio/scheduler/migration/SplitTimersByMethodMigrationTest.java
@@ -2,6 +2,7 @@ package org.folio.scheduler.migration;
 
 import static java.util.List.of;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.scheduler.domain.entity.TimerDescriptorEntity.toNaturalKey;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -67,9 +68,9 @@ class SplitTimersByMethodMigrationTest {
 
     when(mockResultSet.getString("id")).thenReturn(uuid1.toString()).thenReturn(uuid2.toString());
     when(mockSchedulerTimerRepository.findById(uuid1)).thenReturn(
-      Optional.of(TimerDescriptorEntity.of(new TimerDescriptor(routingEntry1, true))));
+      Optional.of(entity(new TimerDescriptor(routingEntry1, true))));
     when(mockSchedulerTimerRepository.findById(uuid2)).thenReturn(
-      Optional.of(TimerDescriptorEntity.of(new TimerDescriptor(routingEntry2, false))));
+      Optional.of(entity(new TimerDescriptor(routingEntry2, false))));
 
     var methodsPassed = new ArrayList<>();
     when(mockSchedulerTimerRepository.save(any())).thenAnswer(inv -> {
@@ -112,5 +113,13 @@ class SplitTimersByMethodMigrationTest {
       when(mockPrepStatement.executeQuery()).thenReturn(mockQueryResponse.getValue());
     }
     return mockLiquibaseDbAccess;
+  }
+
+  private static TimerDescriptorEntity entity(TimerDescriptor timerDescriptor) {
+    var entity = new TimerDescriptorEntity();
+    entity.setId(timerDescriptor.getId());
+    entity.setTimerDescriptor(timerDescriptor);
+    entity.setNaturalKey(toNaturalKey(timerDescriptor));
+    return entity;
   }
 }

--- a/src/test/java/org/folio/scheduler/migration/SplitTimersByMethodMigrationTest.java
+++ b/src/test/java/org/folio/scheduler/migration/SplitTimersByMethodMigrationTest.java
@@ -3,6 +3,7 @@ package org.folio.scheduler.migration;
 import static java.util.List.of;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.scheduler.domain.entity.TimerDescriptorEntity.toNaturalKey;
+import static org.folio.scheduler.support.TestValues.MODULE_NAME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -68,9 +69,9 @@ class SplitTimersByMethodMigrationTest {
 
     when(mockResultSet.getString("id")).thenReturn(uuid1.toString()).thenReturn(uuid2.toString());
     when(mockSchedulerTimerRepository.findById(uuid1)).thenReturn(
-      Optional.of(entity(new TimerDescriptor(routingEntry1, true))));
+      Optional.of(entity(new TimerDescriptor(routingEntry1, true).moduleName(MODULE_NAME))));
     when(mockSchedulerTimerRepository.findById(uuid2)).thenReturn(
-      Optional.of(entity(new TimerDescriptor(routingEntry2, false))));
+      Optional.of(entity(new TimerDescriptor(routingEntry2, false).moduleName(MODULE_NAME))));
 
     var methodsPassed = new ArrayList<>();
     when(mockSchedulerTimerRepository.save(any())).thenAnswer(inv -> {

--- a/src/test/java/org/folio/scheduler/service/SchedulerTimerServiceTest.java
+++ b/src/test/java/org/folio/scheduler/service/SchedulerTimerServiceTest.java
@@ -136,6 +136,15 @@ class SchedulerTimerServiceTest {
   }
 
   @Test
+  void create_negative_timerTypeIsNull() {
+    var descriptor = timerDescriptor().type(null);
+
+    assertThatThrownBy(() -> schedulerTimerService.create(descriptor))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Timer type is required");
+  }
+
+  @Test
   void update_positive() {
     var expectedDescriptor = timerDescriptor().moduleId(MODULE_ID).modified(true);
     var existingEntity = timerDescriptorEntity();
@@ -183,6 +192,15 @@ class SchedulerTimerServiceTest {
     assertThatThrownBy(() -> schedulerTimerService.update(TIMER_UUID, descriptor))
       .isInstanceOf(IllegalArgumentException.class)
       .hasMessage("Module id or module name is required");
+  }
+
+  @Test
+  void update_negative_timerTypeIsNull() {
+    var descriptor = timerDescriptor().type(null);
+
+    assertThatThrownBy(() -> schedulerTimerService.update(TIMER_UUID, descriptor))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Timer type is required");
   }
 
   @Test

--- a/src/test/java/org/folio/scheduler/service/SchedulerTimerServiceTest.java
+++ b/src/test/java/org/folio/scheduler/service/SchedulerTimerServiceTest.java
@@ -128,7 +128,7 @@ class SchedulerTimerServiceTest {
 
   @Test
   void create_negative_moduleIdAndNameIsEmpty() {
-    var descriptor = timerDescriptor();
+    var descriptor = timerDescriptor().moduleId(null).moduleName(null);
 
     assertThatThrownBy(() -> schedulerTimerService.create(descriptor))
       .isInstanceOf(IllegalArgumentException.class)
@@ -178,7 +178,7 @@ class SchedulerTimerServiceTest {
 
   @Test
   void update_negative_moduleIdAndNameIsEmpty() {
-    var descriptor = timerDescriptor();
+    var descriptor = timerDescriptor().moduleId(null).moduleName(null);
 
     assertThatThrownBy(() -> schedulerTimerService.update(TIMER_UUID, descriptor))
       .isInstanceOf(IllegalArgumentException.class)

--- a/src/test/java/org/folio/scheduler/service/SchedulerTimerServiceTest.java
+++ b/src/test/java/org/folio/scheduler/service/SchedulerTimerServiceTest.java
@@ -38,6 +38,8 @@ import org.springframework.data.domain.PageImpl;
 @ExtendWith(MockitoExtension.class)
 class SchedulerTimerServiceTest {
 
+  private static final String MODULE_ID = "mod-foo-1.0.0";
+
   @InjectMocks SchedulerTimerService schedulerTimerService;
   @Mock private SchedulerTimerRepository schedulerTimerRepository;
   @Mock private TimerDescriptorMapper timerDescriptorMapper;
@@ -88,8 +90,8 @@ class SchedulerTimerServiceTest {
 
   @Test
   void create_positive() {
-    var descriptor = timerDescriptor();
-    var entity = timerDescriptorEntity();
+    var descriptor = timerDescriptor().moduleId(MODULE_ID);
+    var entity = timerDescriptorEntity(descriptor);
 
     when(timerDescriptorMapper.convert(descriptor)).thenReturn(entity);
     when(schedulerTimerRepository.save(entity)).thenReturn(entity);
@@ -101,7 +103,7 @@ class SchedulerTimerServiceTest {
 
   @Test
   void create_positive_entityIdIsNull() {
-    var descriptor = timerDescriptor(null);
+    var descriptor = timerDescriptor(null).moduleId(MODULE_ID);
     when(timerDescriptorMapper.convert(timerDescriptorCaptor.capture()))
       .thenAnswer(inv -> timerDescriptorEntity(inv.getArgument(0)));
     when(schedulerTimerRepository.save(any(TimerDescriptorEntity.class))).thenAnswer(inv -> inv.getArgument(0));
@@ -125,8 +127,17 @@ class SchedulerTimerServiceTest {
   }
 
   @Test
+  void create_negative_moduleIdAndNameIsEmpty() {
+    var descriptor = timerDescriptor();
+
+    assertThatThrownBy(() -> schedulerTimerService.create(descriptor))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Module id or module name is required");
+  }
+
+  @Test
   void update_positive() {
-    var expectedDescriptor = timerDescriptor().modified(true);
+    var expectedDescriptor = timerDescriptor().moduleId(MODULE_ID).modified(true);
     var existingEntity = timerDescriptorEntity();
     var entityToUpdate = timerDescriptorEntity(expectedDescriptor);
 
@@ -135,7 +146,7 @@ class SchedulerTimerServiceTest {
     when(schedulerTimerRepository.save(entityToUpdate)).thenReturn(entityToUpdate);
     doNothing().when(jobSchedulingService).reschedule(existingEntity.getTimerDescriptor(), expectedDescriptor);
 
-    var actual = schedulerTimerService.update(TIMER_UUID, timerDescriptor());
+    var actual = schedulerTimerService.update(TIMER_UUID, timerDescriptor().moduleId(MODULE_ID));
 
     assertThat(actual).isEqualTo(expectedDescriptor);
   }
@@ -158,11 +169,20 @@ class SchedulerTimerServiceTest {
 
   @Test
   void update_negative_entityNotFound() {
-    var descriptor = timerDescriptor();
+    var descriptor = timerDescriptor().moduleId(MODULE_ID);
     when(schedulerTimerRepository.findById(TIMER_UUID)).thenReturn(Optional.empty());
     assertThatThrownBy(() -> schedulerTimerService.update(TIMER_UUID, descriptor))
       .isInstanceOf(EntityNotFoundException.class)
       .hasMessage("Unable to find timer descriptor with id " + TIMER_UUID);
+  }
+
+  @Test
+  void update_negative_moduleIdAndNameIsEmpty() {
+    var descriptor = timerDescriptor();
+
+    assertThatThrownBy(() -> schedulerTimerService.update(TIMER_UUID, descriptor))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Module id or module name is required");
   }
 
   @Test
@@ -199,9 +219,9 @@ class SchedulerTimerServiceTest {
 
   @Test
   void create_duplicate() {
-    var descriptor = timerDescriptor();
+    var descriptor = timerDescriptor().moduleId(MODULE_ID);
     descriptor.setId(null);
-    var entity = timerDescriptorEntity();
+    var entity = timerDescriptorEntity(descriptor);
 
     when(timerDescriptorMapper.convert(descriptor)).thenReturn(entity);
     when(schedulerTimerRepository.save(entity)).thenReturn(entity);

--- a/src/test/java/org/folio/scheduler/service/jobs/OkapiHttpRequestExecutorTest.java
+++ b/src/test/java/org/folio/scheduler/service/jobs/OkapiHttpRequestExecutorTest.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import org.folio.scheduler.configuration.properties.OkapiConfigurationProperties;
 import org.folio.scheduler.domain.dto.RoutingEntry;
 import org.folio.scheduler.domain.dto.TimerDescriptor;
+import org.folio.scheduler.domain.dto.TimerType;
 import org.folio.scheduler.integration.OkapiClient;
 import org.folio.scheduler.service.SchedulerTimerService;
 import org.folio.scheduler.service.UserImpersonationService;
@@ -178,6 +179,6 @@ class OkapiHttpRequestExecutorTest {
   }
 
   private static TimerDescriptor timerDescriptor(RoutingEntry re) {
-    return TestValues.timerDescriptor().routingEntry(re).moduleId(TEST_MODULE_ID);
+    return TestValues.timerDescriptor().type(TimerType.SYSTEM).routingEntry(re).moduleId(TEST_MODULE_ID);
   }
 }

--- a/src/test/java/org/folio/scheduler/support/TestValues.java
+++ b/src/test/java/org/folio/scheduler/support/TestValues.java
@@ -14,6 +14,8 @@ import org.folio.scheduler.domain.entity.TimerDescriptorEntity;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TestValues {
 
+  public static final String MODULE_NAME = "mod-foo";
+
   public static UUID randomUuid() {
     return UUID.randomUUID();
   }
@@ -26,6 +28,7 @@ public class TestValues {
     return new TimerDescriptor()
       .id(uuid)
       .enabled(true)
+      .moduleName(MODULE_NAME)
       .routingEntry(new RoutingEntry()
         .methods(List.of("POST"))
         .pathPattern("/testb/timer/20")

--- a/src/test/java/org/folio/scheduler/support/TestValues.java
+++ b/src/test/java/org/folio/scheduler/support/TestValues.java
@@ -41,6 +41,8 @@ public class TestValues {
     var entity = new TimerDescriptorEntity();
     entity.setId(TIMER_UUID);
     entity.setTimerDescriptor(descriptor);
+    entity.setModuleId(descriptor.getModuleId());
+    entity.setModuleName(descriptor.getModuleName());
     return entity;
   }
 }

--- a/src/test/java/org/folio/scheduler/support/TestValues.java
+++ b/src/test/java/org/folio/scheduler/support/TestValues.java
@@ -15,6 +15,7 @@ import org.folio.scheduler.domain.entity.TimerDescriptorEntity;
 public class TestValues {
 
   public static final String MODULE_NAME = "mod-foo";
+  public static final String MODULE_ID = "mod-foo-1.0.0";
 
   public static UUID randomUuid() {
     return UUID.randomUUID();

--- a/src/test/java/org/folio/scheduler/utils/TimerDescriptorUtilsTest.java
+++ b/src/test/java/org/folio/scheduler/utils/TimerDescriptorUtilsTest.java
@@ -1,0 +1,36 @@
+package org.folio.scheduler.utils;
+
+import static org.folio.scheduler.support.TestValues.MODULE_ID;
+import static org.folio.scheduler.support.TestValues.MODULE_NAME;
+import static org.folio.scheduler.utils.TimerDescriptorUtils.evalModuleName;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.of;
+
+import java.util.stream.Stream;
+import org.folio.scheduler.domain.dto.TimerDescriptor;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class TimerDescriptorUtilsTest {
+
+  @ParameterizedTest
+  @MethodSource("evalModuleNameArguments")
+  void testEvalModuleName(String moduleId, String moduleName, String expected) {
+    var td = new TimerDescriptor()
+      .moduleId(moduleId).moduleName(moduleName);
+
+    String result = evalModuleName(td);
+
+    assertEquals(expected, result);
+  }
+
+  static Stream<Arguments> evalModuleNameArguments() {
+    return Stream.of(
+      of(MODULE_ID, MODULE_NAME, MODULE_NAME),
+      of(MODULE_ID, null, MODULE_NAME),
+      of(null, MODULE_NAME, MODULE_NAME),
+      of(null, null, null)
+    );
+  }
+}

--- a/src/test/resources/json/events/folio-app1/mod-foo/create-timer-event.json
+++ b/src/test/resources/json/events/folio-app1/mod-foo/create-timer-event.json
@@ -1,14 +1,14 @@
 {
-  "type": "DELETE",
+  "type": "CREATE",
   "tenant": "test",
   "resourceName": "Scheduled Job",
-  "old": {
-    "moduleId": "folio-module1-1.0.0",
+  "new": {
+    "moduleId": "mod-foo-1.0.0",
     "applicationId": "folio-app1-1.1.1",
     "timers": [
       {
         "methods": [ "GET" ],
-        "pathPattern": "/folio-module1/v3/scheduled-timer",
+        "pathPattern": "/mod-foo/v3/another-scheduled-timer",
         "schedule": {
           "cron": "0 6,18 * * *",
           "zone": "CET"

--- a/src/test/resources/json/events/folio-app1/mod-foo/delete-timer-event.json
+++ b/src/test/resources/json/events/folio-app1/mod-foo/delete-timer-event.json
@@ -1,14 +1,14 @@
 {
-  "type": "CREATE",
+  "type": "DELETE",
   "tenant": "test",
   "resourceName": "Scheduled Job",
-  "new": {
-    "moduleId": "folio-module1-1.0.0",
+  "old": {
+    "moduleId": "mod-foo-1.0.0",
     "applicationId": "folio-app1-1.1.1",
     "timers": [
       {
         "methods": [ "GET" ],
-        "pathPattern": "/folio-module1/v3/another-scheduled-timer",
+        "pathPattern": "/mod-foo/v3/scheduled-timer",
         "schedule": {
           "cron": "0 6,18 * * *",
           "zone": "CET"

--- a/src/test/resources/json/events/folio-app1/mod-foo/upgrade-timer-event.json
+++ b/src/test/resources/json/events/folio-app1/mod-foo/upgrade-timer-event.json
@@ -3,12 +3,12 @@
   "tenant": "test",
   "resourceName": "Scheduled Job",
   "old": {
-    "moduleId": "folio-module1-1.0.0",
+    "moduleId": "mod-foo-1.0.0",
     "applicationId": "folio-app1-1.1.1",
     "timers": [
       {
         "methods": [ "GET" ],
-        "pathPattern": "/folio-module1/v3/scheduled-timer",
+        "pathPattern": "/mod-foo/v3/scheduled-timer",
         "schedule": {
           "cron": "0 6,18 * * *",
           "zone": "CET"
@@ -17,12 +17,12 @@
     ]
   },
   "new": {
-    "moduleId": "folio-module1-1.0.2",
+    "moduleId": "mod-foo-1.0.2",
     "applicationId": "folio-app1-1.1.2",
     "timers": [
       {
         "methods": [ "GET" ],
-        "pathPattern": "/folio-module1/v3/scheduled-timer",
+        "pathPattern": "/mod-foo/v3/scheduled-timer",
         "unit": "second",
         "delay": "20"
       }

--- a/src/test/resources/json/user/timer/user-timer-request.json
+++ b/src/test/resources/json/user/timer/user-timer-request.json
@@ -1,9 +1,9 @@
 {
   "enabled": true,
-  "moduleId": "folio-module1-1.0.0",
+  "moduleId": "mod-foo-1.0.0",
   "routingEntry": {
     "methods": [ "GET" ],
-    "pathPattern": "/folio-module1/v3/scheduled-timer",
+    "pathPattern": "/mod-foo/v3/scheduled-timer",
     "schedule": {
       "cron": "0 6,18 * * *",
       "zone": "CET"

--- a/src/test/resources/json/user/timer/user-timer-request.json
+++ b/src/test/resources/json/user/timer/user-timer-request.json
@@ -1,5 +1,6 @@
 {
   "enabled": true,
+  "moduleId": "folio-module1-1.0.0",
   "routingEntry": {
     "methods": [ "GET" ],
     "pathPattern": "/folio-module1/v3/scheduled-timer",

--- a/src/test/resources/sql/timer-descriptor-it.sql
+++ b/src/test/resources/sql/timer-descriptor-it.sql
@@ -1,9 +1,10 @@
-insert into test_mod_scheduler.timer(id, timer_descriptor)
+insert into test_mod_scheduler.timer(id, module_id, module_name, timer_descriptor)
 values
-    ('123e4567-e89b-12d3-a456-426614174000', '{
+    ('123e4567-e89b-12d3-a456-426614174000', 'mod-foo-1.0.0', 'mod-foo', '{
         "id":"123e4567-e89b-12d3-a456-426614174000",
         "modified": "false",
         "enabled": "true",
+        "moduleId": "mod-foo-1.0.0",
         "routingEntry": {
            "methods": [
              "POST"
@@ -14,9 +15,10 @@ values
         }
        }'
     ),
-    ('123e4567-e89b-12d3-a456-426614174001', '{
+    ('123e4567-e89b-12d3-a456-426614174001', 'mod-foo-1.0.0', 'mod-foo', '{
         "id": "123e4567-e89b-12d3-a456-426614174001",
         "modified": "false",
+        "moduleId": "mod-foo-1.0.0",
         "routingEntry": {
            "methods": [
              "POST"
@@ -28,9 +30,10 @@ values
         }
        }'
     ),
-    ('123e4567-e89b-12d3-a456-426614174002', '{
+    ('123e4567-e89b-12d3-a456-426614174002', 'mod-foo-1.0.0', 'mod-foo', '{
         "id": "123e4567-e89b-12d3-a456-426614174002",
         "modified": "false",
+        "moduleId": "mod-foo-1.0.0",
         "routingEntry": {
           "methods": [
             "POST"

--- a/src/test/resources/sql/timer-descriptor-it.sql
+++ b/src/test/resources/sql/timer-descriptor-it.sql
@@ -1,10 +1,12 @@
-insert into test_mod_scheduler.timer(id, module_id, module_name, timer_descriptor)
+insert into test_mod_scheduler.timer(id, module_id, module_name, type, timer_descriptor)
 values
-    ('123e4567-e89b-12d3-a456-426614174000', 'mod-foo-1.0.0', 'mod-foo', '{
+    ('123e4567-e89b-12d3-a456-426614174000', 'mod-foo-1.0.0', 'mod-foo', 'USER', '{
         "id":"123e4567-e89b-12d3-a456-426614174000",
         "modified": "false",
         "enabled": "true",
         "moduleId": "mod-foo-1.0.0",
+        "moduleName": "mod-foo",
+        "type": "user",
         "routingEntry": {
            "methods": [
              "POST"
@@ -15,10 +17,12 @@ values
         }
        }'
     ),
-    ('123e4567-e89b-12d3-a456-426614174001', 'mod-foo-1.0.0', 'mod-foo', '{
+    ('123e4567-e89b-12d3-a456-426614174001', 'mod-foo-1.0.0', 'mod-foo', 'USER', '{
         "id": "123e4567-e89b-12d3-a456-426614174001",
         "modified": "false",
         "moduleId": "mod-foo-1.0.0",
+        "moduleName": "mod-foo",
+        "type": "user",
         "routingEntry": {
            "methods": [
              "POST"
@@ -30,10 +34,12 @@ values
         }
        }'
     ),
-    ('123e4567-e89b-12d3-a456-426614174002', 'mod-foo-1.0.0', 'mod-foo', '{
+    ('123e4567-e89b-12d3-a456-426614174002', 'mod-foo-1.0.0', 'mod-foo', 'USER', '{
         "id": "123e4567-e89b-12d3-a456-426614174002",
         "modified": "false",
         "moduleId": "mod-foo-1.0.0",
+        "moduleName": "mod-foo",
+        "type": "user",
         "routingEntry": {
           "methods": [
             "POST"

--- a/src/test/resources/wiremock/stubs/event-timer-endpoint.json
+++ b/src/test/resources/wiremock/stubs/event-timer-endpoint.json
@@ -16,7 +16,7 @@
         "matches" : "^\\d{6}$"
       },
       "x-okapi-url": {
-        "matches" : "^http://localhost:\\d{1,5}$"
+        "matches" : "^http://[a-zA-Z0-9.-]+:\\d{1,5}$"
       }
     }
   },

--- a/src/test/resources/wiremock/stubs/event-timer-endpoint.json
+++ b/src/test/resources/wiremock/stubs/event-timer-endpoint.json
@@ -5,6 +5,18 @@
     "headers": {
       "Content-Type": {
         "equalTo": "application/json"
+      },
+      "x-okapi-module-hint": {
+        "matches" : "^folio\\-module1\\-\\d\\.\\d\\.\\d$"
+      },
+      "x-okapi-tenant": {
+        "equalTo": "test"
+      },
+      "x-okapi-request-id": {
+        "matches" : "^\\d{6}$"
+      },
+      "x-okapi-url": {
+        "matches" : "^http://localhost:\\d{1,5}$"
       }
     }
   },

--- a/src/test/resources/wiremock/stubs/timer-endpoint.json
+++ b/src/test/resources/wiremock/stubs/timer-endpoint.json
@@ -16,7 +16,7 @@
         "matches" : "^\\d{6}$"
       },
       "x-okapi-url": {
-        "matches" : "^http://localhost:\\d{1,5}$"
+        "matches" : "^http://[a-zA-Z0-9.-]+:\\d{1,5}$"
       }
     }
   },

--- a/src/test/resources/wiremock/stubs/timer-endpoint.json
+++ b/src/test/resources/wiremock/stubs/timer-endpoint.json
@@ -5,6 +5,18 @@
     "headers": {
       "Content-Type": {
         "equalTo": "application/json"
+      },
+      "x-okapi-module-hint": {
+        "equalTo": "mod-foo-1.0.0"
+      },
+      "x-okapi-tenant": {
+        "equalTo": "test"
+      },
+      "x-okapi-request-id": {
+        "matches" : "^\\d{6}$"
+      },
+      "x-okapi-url": {
+        "matches" : "^http://localhost:\\d{1,5}$"
       }
     }
   },

--- a/src/test/resources/wiremock/stubs/user-timer-endpoint.json
+++ b/src/test/resources/wiremock/stubs/user-timer-endpoint.json
@@ -16,7 +16,7 @@
         "matches" : "^\\d{6}$"
       },
       "x-okapi-url": {
-        "matches" : "^http://localhost:\\d{1,5}$"
+        "matches" : "^http://[a-zA-Z0-9.-]+:\\d{1,5}$"
       }
     }
   },

--- a/src/test/resources/wiremock/stubs/user-timer-endpoint.json
+++ b/src/test/resources/wiremock/stubs/user-timer-endpoint.json
@@ -1,13 +1,13 @@
 {
   "request": {
-    "method": "GET",
-    "urlPattern": "/mod-foo/v3/scheduled-timer",
+    "method": "POST",
+    "url": "/test",
     "headers": {
       "Content-Type": {
         "equalTo": "application/json"
       },
       "x-okapi-module-hint": {
-        "matches" : "^mod\\-foo\\-\\d\\.\\d\\.\\d$"
+        "equalTo": "mod-foo"
       },
       "x-okapi-tenant": {
         "equalTo": "test"
@@ -21,7 +21,7 @@
     }
   },
   "response": {
-    "status": 200,
+    "status": 201,
     "headers": {
       "Content-Type": "application/json"
     },


### PR DESCRIPTION
## Purpose
We need to integrate internal route discovery functionality directly into the Sidecar component to remove reliance on Kong for internal route resolution. The goal is to ensure that the Sidecar independently manages all route discovery and caching for internal system calls. Additionally, a Dynamic Routing Enabled/Disabled switch must be implemented, which can be controlled via a configuration parameter. When dynamic routing is enabled, the Sidecar will perform dynamic route discovery. When disabled, it will use pre-configured routes loaded during bootstrap.

This change will simplify the internal routing architecture by removing Kong from the timer workflow, making the Sidecar responsible for handling route discovery and forwarding.
US: [MODSCHED-24](https://folio-org.atlassian.net/browse/MODSCHED-24)

## Approach
* introduce a new field, called `type`, in timer descriptor to explicitly specify the type of timer: `USER` or `SYSTEM`
* for each system timer save module id of the module this timer belongs to; for user timers module name should be provided or module id (if possible)
* make either module id or module name required in timer descriptors
* when timer is triggered, send a new header called `x-okapi-module-hint` which should be populated:
** with module name – for user timers
** with module id or module name (if module id is missing) – for system timers
* provide sql scripts to support the new timer descriptor fields
* prepare sql migration scripts to update existing timers

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
