### PR TITLE
Upgrade postgres container from 12 to 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ docker run \
   -e POSTGRES_USERNAME=postgres \
   -e POSTGRES_PASSWORD=mysecretpassword \
   -p 5432:5432 \
-  -d postgres:12.11
+  -d postgres:16-alpine
 ```
 
 Build the docker container with:


### PR DESCRIPTION
### **Purpose**
Version 16 is the only officially supported Postgres version since Ramsons: https://folio-org.atlassian.net/wiki/spaces/TC/pages/5058042/Ramsons#Ramsons-Infrastructure

### **Approach**
Upgrade postgres container from 12 to 16

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- n/a **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- n/a **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - n/a API/schema changes
  - n/a Interface version updates
  - n/a DB schema changes / migration scripts
- n/a **New Properties / Environment Variables** — Updated README.md if new configs were added.
