### PR TITLE
MODSCHED-35: normalize cron notation to the Quartz format

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## Version `v4.0.0` (in progress)
 ### Changes:
+* Normalize cron notation to the Quartz format (MODSCHED-33)
 ---
 
 ## Version `v3.0.0` (12.03.2025)

--- a/README.md
+++ b/README.md
@@ -176,3 +176,17 @@ in [application.yml](./src/main/resources/application.yml) under `spring.quartz`
 
 In addition, Quartz can be tuned
 using [Quart configuration properties](http://www.quartz-scheduler.org/documentation/2.4.0-SNAPSHOT/configuration.html)
+
+
+### Cron format for timers
+`mod-scheduler` supports both Unix and Quartz cron formats for timers. The Unix format is automatically converted to Quartz, so you can use either format for cron-based timers. The formats are as follows:
+
+**Unix cron format:**
+
+```
+<minute> <hour> <day-of-month> <month> <day-of-week>
+```
+**Quartz cron format:**
+```
+<second> <minute> <hour> <day-of-month> <month> <day-of-week> [year]
+```

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
     <applications-poc-tools.version>3.1.0-SNAPSHOT</applications-poc-tools.version>
     <aws.version>2.31.59</aws.version>
     <vault.version>5.1.0</vault.version>
+    <cron-utils.version>9.1.7</cron-utils.version>
 
     <mod-scheduler.yaml-file>${project.basedir}/src/main/resources/swagger.api/mod-scheduler.yaml
     </mod-scheduler.yaml-file>
@@ -225,6 +226,12 @@
       <groupId>io.swagger.core.v3</groupId>
       <artifactId>swagger-annotations</artifactId>
       <version>${swagger-annotations.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.cronutils</groupId>
+      <artifactId>cron-utils</artifactId>
+      <version>${cron-utils.version}</version>
     </dependency>
 
     <!-- Test dependencies -->

--- a/src/main/java/org/folio/scheduler/configuration/RetryConfiguration.java
+++ b/src/main/java/org/folio/scheduler/configuration/RetryConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
 import org.springframework.retry.RetryListener;
 import org.springframework.retry.annotation.EnableRetry;
-import org.springframework.retry.listener.RetryListenerSupport;
+import org.springframework.retry.listener.MethodInvocationRetryListenerSupport;
 
 @Log4j2
 @EnableRetry
@@ -16,7 +16,7 @@ public class RetryConfiguration {
 
   @Bean(name = "methodLoggingRetryListener")
   public RetryListener methodLoggingRetryListener() {
-    return new RetryListenerSupport() {
+    return new MethodInvocationRetryListenerSupport() {
 
       @Override
       public <T, E extends Throwable> void onError(RetryContext ctx, RetryCallback<T, E> callback, Throwable t) {

--- a/src/main/java/org/folio/scheduler/service/JobSchedulingService.java
+++ b/src/main/java/org/folio/scheduler/service/JobSchedulingService.java
@@ -15,6 +15,7 @@ import static org.folio.scheduler.domain.dto.TimerUnit.HOUR;
 import static org.folio.scheduler.domain.dto.TimerUnit.MILLISECOND;
 import static org.folio.scheduler.domain.dto.TimerUnit.MINUTE;
 import static org.folio.scheduler.domain.dto.TimerUnit.SECOND;
+import static org.folio.scheduler.utils.CronUtils.convertToQuartz;
 import static org.folio.spring.integration.XOkapiHeaders.TENANT;
 import static org.folio.spring.integration.XOkapiHeaders.USER_ID;
 import static org.quartz.CronScheduleBuilder.cronSchedule;
@@ -182,7 +183,7 @@ public class JobSchedulingService {
     var schedule = timerDescriptor.getRoutingEntry().getSchedule();
     var timeZone = defaultIfNull(schedule.getZone(), "UTC");
     var cron = schedule.getCron();
-    var cronExpression = cron.split("\\s+").length == 5 ? cron + " ?" : cron;
+    var cronExpression = convertToQuartz(cron);
     return newTrigger()
       .withIdentity(triggerKey(timerId))
       .withSchedule(cronSchedule(cronExpression).inTimeZone(getTimeZone(timeZone)))

--- a/src/main/java/org/folio/scheduler/utils/CronUtils.java
+++ b/src/main/java/org/folio/scheduler/utils/CronUtils.java
@@ -1,0 +1,39 @@
+package org.folio.scheduler.utils;
+
+import static com.cronutils.mapper.CronMapper.fromUnixToQuartz;
+import static com.cronutils.model.CronType.UNIX;
+import static com.cronutils.model.definition.CronDefinitionBuilder.instanceDefinitionFor;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+import com.cronutils.mapper.CronMapper;
+import com.cronutils.model.definition.CronDefinition;
+import com.cronutils.parser.CronParser;
+import lombok.experimental.UtilityClass;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+@UtilityClass
+public class CronUtils {
+
+  private static final CronDefinition UNIX_DEF = instanceDefinitionFor(UNIX);
+  private static final CronParser UNIX_PARSER = new CronParser(UNIX_DEF);
+  private static final CronMapper UNIX_TO_QUARTZ_MAPPER = fromUnixToQuartz();
+
+  public static String convertToQuartz(String cronExpression) {
+    requireNonNull(cronExpression, "Cron expression cannot be null.");
+
+    var parts = cronExpression.trim().split("\\s+");
+    if (parts.length == 5) {
+      var unixCron = UNIX_PARSER.parse(cronExpression);
+      var quartzCron = UNIX_TO_QUARTZ_MAPPER.map(unixCron);
+      return quartzCron.asString();
+    } else if (parts.length == 6 || parts.length == 7) {
+      return cronExpression;
+    } else {
+      log.warn("Invalid cron expression: {}. Must have 5 (Unix) or 6/7 (Quartz) fields.", cronExpression);
+      throw new IllegalArgumentException(
+        format("Invalid cron expression: %s. Must have 5 (Unix) or 6/7 (Quartz) fields.", cronExpression));
+    }
+  }
+}

--- a/src/main/java/org/folio/scheduler/utils/CronUtils.java
+++ b/src/main/java/org/folio/scheduler/utils/CronUtils.java
@@ -27,7 +27,9 @@ public class CronUtils {
     if (parts.length == 5) {
       var unixCron = UNIX_PARSER.parse(cronExpression);
       var quartzCron = UNIX_TO_QUARTZ_MAPPER.map(unixCron);
-      return quartzCron.asString();
+      var cron = quartzCron.asString();
+      log.info("Converted Unix cron expression '{}' to Quartz format '{}'", cronExpression, cron);
+      return cron;
     } else if (parts.length == 6 || parts.length == 7) {
       return cronExpression;
     } else {

--- a/src/test/java/org/folio/scheduler/it/SchedulerTimerIT.java
+++ b/src/test/java/org/folio/scheduler/it/SchedulerTimerIT.java
@@ -112,7 +112,7 @@ class SchedulerTimerIT extends BaseIntegrationTest {
   @Test
   @WireMockStub("/wiremock/stubs/user-timer-endpoint.json")
   @KeycloakRealms("/json/keycloak/test-realm.json")
-  void create_positive_cronTrigger() throws Exception {
+  void create_positive_cronTriggerEverySecond() throws Exception {
     var timerId = UUID.randomUUID().toString();
     var timerDescriptor = new TimerDescriptor()
       .id(UUID.fromString(timerId))
@@ -121,7 +121,7 @@ class SchedulerTimerIT extends BaseIntegrationTest {
       .routingEntry(new RoutingEntry()
         .methods(List.of("POST"))
         .pathPattern("/test")
-        .schedule(new RoutingEntrySchedule().cron("*/1 * * * *")));
+        .schedule(new RoutingEntrySchedule().cron("* * * * * ?")));
 
     var timestampBeforeSavingDesc = Instant.now();
     doPost("/scheduler/timers", timerDescriptor)

--- a/src/test/java/org/folio/scheduler/utils/CronUtilsTest.java
+++ b/src/test/java/org/folio/scheduler/utils/CronUtilsTest.java
@@ -1,0 +1,65 @@
+package org.folio.scheduler.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.stream.Stream;
+import org.folio.test.types.UnitTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@UnitTest
+class CronUtilsTest {
+
+  @ParameterizedTest(name = "[{index}] «{0}» → «{1}»")
+  @MethodSource("validConversions")
+  void convertToQuartz_positive(String input, String expected) {
+    assertEquals(expected, CronUtils.convertToQuartz(input));
+  }
+
+  @ParameterizedTest(name = "[{index}] invalid «{0}»")
+  @MethodSource("invalidInputs")
+  void convertToQuartz_negative(String invalidExpression) {
+    assertThrows(IllegalArgumentException.class, () -> CronUtils.convertToQuartz(invalidExpression));
+  }
+
+  @ParameterizedTest(name = "[{index}] null → NPE")
+  @MethodSource("provideNull")
+  void convertToQuartz_negative_npe(String ignored) {
+    assertThrows(NullPointerException.class, () -> CronUtils.convertToQuartz(null));
+  }
+
+  static Stream<Arguments> provideNull() {
+    return Stream.of(Arguments.of((String) null));
+  }
+
+  static Stream<Arguments> invalidInputs() {
+    return Stream.of(
+      Arguments.of(""),
+      Arguments.of("   "),
+      Arguments.of("* * *"),
+      Arguments.of("a b c d e f g h"),
+      Arguments.of("*/1 * * *")
+    );
+  }
+
+  static Stream<Arguments> validConversions() {
+    return Stream.of(
+      // UNIX → Quartz
+      Arguments.of("* * * * *", "0 * * * * ? *"),
+      Arguments.of("*/5 * * * *", "0 */5 * * * ? *"),
+      Arguments.of("0 * * * *", "0 0 * * * ? *"),
+      Arguments.of("30 15 * * MON-FRI", "0 30 15 ? * 2-6 *"),
+      Arguments.of("0 12 1 1 *", "0 0 12 1 1 ? *"),
+
+      // Quartz-6
+      Arguments.of("0 0 12 * * ?", "0 0 12 * * ?"),
+      Arguments.of("5 15 10 * * MON-FRI", "5 15 10 * * MON-FRI"),
+
+      // Quartz-7
+      Arguments.of("0 0 12 * * ? 2025", "0 0 12 * * ? 2025"),
+      Arguments.of("30 0 0 1 1 ? 2025/2", "30 0 0 1 1 ? 2025/2")
+    );
+  }
+}


### PR DESCRIPTION
### **Purpose**
https://folio-org.atlassian.net/browse/MODSCHED-35
Eureka replaces Okapi’s implementation of the _timer interface with mod-scheduler.  Unfortunately, the two use slightly different variations of the cron expression format.  Okapi expects the “Unix” format, which has minute precision.  Eureka (mgr-tenant-entitlements/mod-scheduler) expect the “Quartz” format, which has second precision and supports other features.  Since we’re striving to maintain backwards compatibility at the module level as much as possible with the Okapi platform, we don’t want to change the cron notation in the module descriptors.  Instead we will make changes in Eureka to support both expression formats.

### **Approach**
- add `cron-utils` dependencies
- implement unix to quartz cron format converter
- fix/add tests

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [x] **New Properties / Environment Variables** — Updated README.md if new configs were added.
