### PR TITLE
MODSCHED-37: add migration for cron-based timers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 ### Changes:
 * Normalize cron notation to the Quartz format (MODSCHED-33)
 * Introduce configuration for FSSP (APPPOCTOOL-59)
+* Add migration for cron-based timers (MODSCHED-37)
 ---
 
 ## Version `v3.0.0` (12.03.2025)

--- a/src/main/resources/changelog/changelog-master.xml
+++ b/src/main/resources/changelog/changelog-master.xml
@@ -12,4 +12,5 @@
   <include file="changes/05_populate_natural_key_and_deduplicate.xml" relativeToChangelogFile="true"/>
   <include file="changes/06_add_module_id_column_to_timer.xml" relativeToChangelogFile="true"/>
   <include file="changes/07_add_type_column_to_timer.xml" relativeToChangelogFile="true"/>
+  <include file="changes/08_mark_cron_based_timers_as_outdated.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changelog/changes/08_mark_cron_based_timers_as_outdated.xml
+++ b/src/main/resources/changelog/changes/08_mark_cron_based_timers_as_outdated.xml
@@ -1,0 +1,19 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
+  <changeSet id="mark cron-based timer as outdated" author="Yauhen Vavilkin">
+    <sql>
+      -- mark cron-based timers as outdated by changing their zone to "NON", next received timers event will reschedule timers
+      UPDATE timer
+      SET timer_descriptor = jsonb_set(
+        timer_descriptor,
+        '{routingEntry,schedule,zone}',
+        '"NON"',
+        false
+      )
+      WHERE timer_descriptor #>> '{routingEntry,schedule,cron}' IS NOT NULL;
+    </sql>
+  </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
### **Purpose**
https://folio-org.atlassian.net/browse/MODSCHED-37
After we fixed Unix-based cron to Quartz cron format conversion, we should to migrate Quartz cron jobs created with the wrong conversion.

### **Approach**
- add Liquibase script
---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
