### PR TITLE
MODSCHED-45 - remove @Import, use beans from auto configurations

### DIFF
--- a/src/main/java/org/folio/scheduler/integration/keycloak/configuration/KeycloakConfiguration.java
+++ b/src/main/java/org/folio/scheduler/integration/keycloak/configuration/KeycloakConfiguration.java
@@ -17,8 +17,6 @@ import org.folio.scheduler.integration.keycloak.configuration.exception.NotFound
 import org.folio.scheduler.integration.keycloak.configuration.properties.KeycloakProperties;
 import org.folio.security.integration.keycloak.service.SecureStoreKeyProvider;
 import org.folio.tools.store.SecureStore;
-import org.folio.tools.store.configuration.SecureStoreAutoconfiguration;
-import org.folio.tools.store.properties.SecureStoreProperties;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
@@ -26,14 +24,12 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 
 @Log4j2
 @Configuration
 @ConditionalOnProperty(name = "application.keycloak.enabled", havingValue = "true")
 @EnableConfigurationProperties(KeycloakProperties.class)
 @RequiredArgsConstructor
-@Import(SecureStoreAutoconfiguration.class)
 public class KeycloakConfiguration {
 
   private static final DefaultHostnameVerifier DEFAULT_HOSTNAME_VERIFIER = new DefaultHostnameVerifier();
@@ -43,11 +39,6 @@ public class KeycloakConfiguration {
 
   private final KeycloakProperties properties;
   private final SecureStore secureStore;
-
-  @Bean
-  public SecureStoreKeyProvider secureStoreKeyProvider(SecureStoreProperties secureStoreProperties) {
-    return new SecureStoreKeyProvider(secureStoreProperties);
-  }
 
   @Bean
   public Keycloak keycloak(SecureStoreKeyProvider secureStoreKeyProvider) {


### PR DESCRIPTION
### **Purpose**
[MODSCHED-45](https://folio-org.atlassian.net/browse/MODSCHED-45) - Use SECURE_STORE_ENV, not ENV, for secure store key

### **Approach**

Remove SecureStoreKeyProvider bean creation as it is provided by autoconfiguration. 

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
