### PR TITLE
MODSCHED-74: handle Liquibase migration state during Kafka event processing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 * Add Auditable Information to Timer Entity (MODSCHED-62)
 * Migrate CI to GitHub Actions Maven central workflow (MODSCHED-63)
 * Upgrade module to SpringBoot 4.0 and Spring 7.0 (MODSCHED-48)
+* Handle Liquibase migration state during Kafka event processing (MODSCHED-74)
 ---
 
 ## Version `v3.0.0` (12.03.2025)

--- a/src/main/java/org/folio/scheduler/integration/kafka/KafkaMessageListener.java
+++ b/src/main/java/org/folio/scheduler/integration/kafka/KafkaMessageListener.java
@@ -10,8 +10,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.folio.scheduler.integration.kafka.model.EntitlementEvent;
+import org.folio.scheduler.integration.kafka.model.EntitlementEventType;
 import org.folio.scheduler.integration.kafka.model.ResourceEvent;
+import org.folio.scheduler.integration.kafka.model.ResourceEventType;
 import org.folio.spring.FolioModuleMetadata;
+import org.folio.spring.exception.LiquibaseMigrationException;
+import org.folio.spring.liquibase.LiquibaseMigrationLockService;
 import org.folio.spring.scope.FolioExecutionContextSetter;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -22,6 +26,7 @@ import org.springframework.stereotype.Component;
 public class KafkaMessageListener {
 
   private final FolioModuleMetadata folioModuleMetadata;
+  private final LiquibaseMigrationLockService liquibaseMigrationLockService;
   private final KafkaEventService eventService;
 
   /**
@@ -38,9 +43,13 @@ public class KafkaMessageListener {
   public void handleScheduledJobEvent(ConsumerRecord<String, ResourceEvent> consumerRecord) {
     var resourceEvent = consumerRecord.value();
     var tenant = resourceEvent.getTenant();
+    var operationType = resourceEvent.getType();
 
     try (var ignored = new FolioExecutionContextSetter(folioModuleMetadata, prepareContextHeaders(tenant))) {
-      var operationType = resourceEvent.getType();
+      if (requiresLiquibaseReadyState(operationType) && liquibaseMigrationLockService.isMigrationRunning()) {
+        log.warn("Liquibase migration in progress for tenant: {}", tenant);
+        throw new LiquibaseMigrationException("Liquibase migration is still running for tenant: " + tenant);
+      }
 
       log.info("Received job {} event for {} in {}. Thread: {}", operationType, resourceEvent.getResourceName(),
         tenant, Thread.currentThread().getName());
@@ -68,9 +77,13 @@ public class KafkaMessageListener {
   public void handleEntitlementEvent(ConsumerRecord<String, EntitlementEvent> consumerRecord) {
     var event = consumerRecord.value();
     var tenant = event.getTenantName();
+    var operationType = event.getType();
 
     try (var ignored = new FolioExecutionContextSetter(folioModuleMetadata, prepareContextHeaders(tenant))) {
-      var operationType = event.getType();
+      if (requiresLiquibaseReadyState(operationType) && liquibaseMigrationLockService.isMigrationRunning()) {
+        log.warn("Liquibase migration in progress for tenant: {}", tenant);
+        throw new LiquibaseMigrationException("Liquibase migration is still running for tenant: " + tenant);
+      }
 
       log.info("Received entitlement {} event for {} in {}. Thread: {}", operationType, event.getModuleId(),
         tenant, Thread.currentThread().getName());
@@ -91,5 +104,13 @@ public class KafkaMessageListener {
 
   private static void logUnsupportedOperationType(ConsumerRecord<?, ?> consumerRecord) {
     log.warn("Unsupported operation type: consumerRecord = {}", consumerRecord);
+  }
+
+  private static boolean requiresLiquibaseReadyState(ResourceEventType operationType) {
+    return operationType == ResourceEventType.CREATE || operationType == ResourceEventType.UPDATE;
+  }
+
+  private static boolean requiresLiquibaseReadyState(EntitlementEventType operationType) {
+    return operationType == EntitlementEventType.ENTITLE || operationType == EntitlementEventType.UPGRADE;
   }
 }

--- a/src/main/java/org/folio/scheduler/integration/kafka/configuration/KafkaConfiguration.java
+++ b/src/main/java/org/folio/scheduler/integration/kafka/configuration/KafkaConfiguration.java
@@ -12,11 +12,14 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.Strings;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.folio.scheduler.configuration.properties.RetryConfigurationProperties;
+import org.folio.scheduler.configuration.properties.RetryConfigurationProperties.RetryProperties;
 import org.folio.scheduler.integration.kafka.TimerTableCheckService;
 import org.folio.scheduler.integration.kafka.model.EntitlementEvent;
 import org.folio.scheduler.integration.kafka.model.ResourceEvent;
 import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.exception.LiquibaseMigrationException;
 import org.hibernate.exception.SQLGrammarException;
+import org.jspecify.annotations.NonNull;
 import org.springframework.boot.kafka.autoconfigure.KafkaProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -114,15 +117,21 @@ public class KafkaConfiguration {
     return errorHandler;
   }
 
-  private BackOff getBackOff(Exception exception, Class<?> eventClass) {
+  BackOff getBackOff(Exception exception, Class<?> eventClass) {
     log.info("Calculating backoff for exception: exception = {}, eventClass = {}",
       exception.getMessage(), eventClass.getSimpleName(), exception);
+
+    if (hasCause(exception, LiquibaseMigrationException.class)) {
+      var retryProperties = getRetryProperties(eventClass);
+      log.warn("Liquibase migration in progress, retrying Kafka event", exception);
+      return getFixedBackOff(retryProperties);
+    }
 
     var relationDoesNotExistsMessage = findRelationDoesNotExistsMessage(exception);
     if (relationDoesNotExistsMessage.isPresent()) {
       var retryProperties = getRetryProperties(eventClass);
       log.warn("Tenant table is not found, retrying until created [message: {}]", relationDoesNotExistsMessage.get());
-      return new FixedBackOff(retryProperties.getRetryDelay().toMillis(), retryProperties.getRetryAttempts());
+      return getFixedBackOff(retryProperties);
     }
 
     return new FixedBackOff(0L, 0L);
@@ -133,6 +142,20 @@ public class KafkaConfiguration {
       ? "entitlement-event"
       : "scheduled-timer-event";
     return retryConfiguration.getConfig().get(propertyKey);
+  }
+
+  private static @NonNull FixedBackOff getFixedBackOff(RetryProperties retryProperties) {
+    return new FixedBackOff(retryProperties.getRetryDelay().toMillis(), retryProperties.getRetryAttempts());
+  }
+
+  private static boolean hasCause(Throwable throwable, Class<? extends Throwable> expectedType) {
+    for (var current = throwable; current != null; current = current.getCause()) {
+      if (expectedType.isInstance(current)) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   private static Optional<String> findRelationDoesNotExistsMessage(Exception exception) {

--- a/src/test/java/org/folio/scheduler/integration/kafka/KafkaMessageListenerTest.java
+++ b/src/test/java/org/folio/scheduler/integration/kafka/KafkaMessageListenerTest.java
@@ -9,8 +9,12 @@ import static org.folio.scheduler.integration.kafka.model.ResourceEventType.DELE
 import static org.folio.scheduler.integration.kafka.model.ResourceEventType.UPDATE;
 import static org.folio.scheduler.support.TestConstants.TENANT_ID;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -21,6 +25,8 @@ import org.folio.scheduler.integration.kafka.model.EntitlementEventType;
 import org.folio.scheduler.integration.kafka.model.ResourceEvent;
 import org.folio.scheduler.integration.kafka.model.ResourceEventType;
 import org.folio.scheduler.integration.kafka.model.ScheduledTimers;
+import org.folio.spring.exception.LiquibaseMigrationException;
+import org.folio.spring.liquibase.LiquibaseMigrationLockService;
 import org.folio.test.types.UnitTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
@@ -46,6 +52,9 @@ class KafkaMessageListenerTest {
 
   @Mock
   private org.folio.spring.FolioModuleMetadata folioModuleMetadata;
+
+  @Mock
+  private LiquibaseMigrationLockService liquibaseMigrationLockService;
 
   @AfterEach
   void tearDown() {
@@ -111,7 +120,9 @@ class KafkaMessageListenerTest {
 
       kafkaMessageListener.handleScheduledJobEvent(consumerRecord);
 
-      verify(eventService).createTimers(event);
+      var inOrder = inOrder(liquibaseMigrationLockService, eventService);
+      inOrder.verify(liquibaseMigrationLockService).isMigrationRunning();
+      inOrder.verify(eventService).createTimers(event);
     }
 
     @Test
@@ -131,6 +142,18 @@ class KafkaMessageListenerTest {
 
       kafkaMessageListener.handleScheduledJobEvent(consumerRecord);
 
+      verify(eventService).deleteTimers(event);
+    }
+
+    @Test
+    void positive_deleteEventBypassesLiquibasePrecheck() {
+      var event = createResourceEvent(DELETE);
+      var consumerRecord = new ConsumerRecord<>(TOPIC_NAME, 0, 0, TENANT_ID, event);
+      lenient().when(liquibaseMigrationLockService.isMigrationRunning()).thenReturn(true);
+
+      kafkaMessageListener.handleScheduledJobEvent(consumerRecord);
+
+      verifyNoInteractions(liquibaseMigrationLockService);
       verify(eventService).deleteTimers(event);
     }
 
@@ -178,6 +201,19 @@ class KafkaMessageListenerTest {
 
       verify(eventService).deleteTimers(event);
     }
+
+    @Test
+    void handleScheduledJobEvent_negative_liquibaseMigrationInProgress() {
+      var event = createResourceEvent(CREATE);
+      var consumerRecord = new ConsumerRecord<>(TOPIC_NAME, 0, 0, TENANT_ID, event);
+      when(liquibaseMigrationLockService.isMigrationRunning()).thenReturn(true);
+
+      assertThatThrownBy(() -> kafkaMessageListener.handleScheduledJobEvent(consumerRecord))
+        .isInstanceOf(LiquibaseMigrationException.class)
+        .hasMessage("Liquibase migration is still running for tenant: " + TENANT_ID);
+
+      verify(liquibaseMigrationLockService).isMigrationRunning();
+    }
   }
 
   @Nested
@@ -190,7 +226,9 @@ class KafkaMessageListenerTest {
 
       kafkaMessageListener.handleEntitlementEvent(consumerRecord);
 
-      verify(eventService).enableTimers(event);
+      var inOrder = inOrder(liquibaseMigrationLockService, eventService);
+      inOrder.verify(liquibaseMigrationLockService).isMigrationRunning();
+      inOrder.verify(eventService).enableTimers(event);
     }
 
     @Test
@@ -210,6 +248,18 @@ class KafkaMessageListenerTest {
 
       kafkaMessageListener.handleEntitlementEvent(consumerRecord);
 
+      verify(eventService).disableTimers(event);
+    }
+
+    @Test
+    void positive_revokeEventBypassesLiquibasePrecheck() {
+      var event = createEntitlementEvent(REVOKE);
+      var consumerRecord = new ConsumerRecord<>(TOPIC_NAME, 0, 0, TENANT_ID, event);
+      lenient().when(liquibaseMigrationLockService.isMigrationRunning()).thenReturn(true);
+
+      kafkaMessageListener.handleEntitlementEvent(consumerRecord);
+
+      verifyNoInteractions(liquibaseMigrationLockService);
       verify(eventService).disableTimers(event);
     }
 
@@ -241,6 +291,19 @@ class KafkaMessageListenerTest {
         .hasMessage("Failed to disable timers");
 
       verify(eventService).disableTimers(event);
+    }
+
+    @Test
+    void handleEntitlementEvent_negative_liquibaseMigrationInProgress() {
+      var event = createEntitlementEvent(ENTITLE);
+      var consumerRecord = new ConsumerRecord<>(TOPIC_NAME, 0, 0, TENANT_ID, event);
+      when(liquibaseMigrationLockService.isMigrationRunning()).thenReturn(true);
+
+      assertThatThrownBy(() -> kafkaMessageListener.handleEntitlementEvent(consumerRecord))
+        .isInstanceOf(LiquibaseMigrationException.class)
+        .hasMessage("Liquibase migration is still running for tenant: " + TENANT_ID);
+
+      verify(liquibaseMigrationLockService).isMigrationRunning();
     }
   }
 }

--- a/src/test/java/org/folio/scheduler/it/KafkaMessageListenerEntitlementEventsIT.java
+++ b/src/test/java/org/folio/scheduler/it/KafkaMessageListenerEntitlementEventsIT.java
@@ -9,6 +9,9 @@ import static org.folio.scheduler.support.TestConstants.TENANT_ID;
 import static org.folio.scheduler.utils.TestUtils.asJsonString;
 import static org.folio.scheduler.utils.TestUtils.await;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.quartz.impl.matchers.GroupMatcher.anyJobGroup;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
@@ -16,9 +19,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import lombok.extern.log4j.Log4j2;
 import org.folio.scheduler.integration.kafka.model.EntitlementEvent;
-import org.folio.scheduler.repository.SchedulerTimerRepository;
 import org.folio.scheduler.support.base.BaseIntegrationTest;
-import org.folio.spring.FolioModuleMetadata;
+import org.folio.spring.liquibase.LiquibaseMigrationLockService;
 import org.folio.test.extensions.EnableKeycloakTlsMode;
 import org.folio.test.extensions.KeycloakRealms;
 import org.folio.test.extensions.WireMockStub;
@@ -30,6 +32,7 @@ import org.quartz.Scheduler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.core.KafkaAdmin;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.jdbc.Sql;
 
 @Log4j2
@@ -44,11 +47,9 @@ class KafkaMessageListenerEntitlementEventsIT extends BaseIntegrationTest {
   @Autowired
   private KafkaTemplate<String, String> kafkaTemplate;
   @Autowired
-  private SchedulerTimerRepository repository;
-  @Autowired
-  private FolioModuleMetadata folioModuleMetadata;
-  @Autowired
   private Scheduler scheduler;
+  @MockitoBean
+  private LiquibaseMigrationLockService liquibaseMigrationLockService;
 
   @BeforeAll
   static void beforeAll(@Autowired KafkaAdmin kafkaAdmin) {
@@ -88,6 +89,23 @@ class KafkaMessageListenerEntitlementEventsIT extends BaseIntegrationTest {
       });
     await().atMost(TEN_SECONDS).pollDelay(ONE_HUNDRED_MILLISECONDS)
       .untilAsserted(() -> assertThat(scheduler.getJobKeys(anyJobGroup())).isEmpty());
+  }
+
+  @Test
+  @KeycloakRealms("/json/keycloak/test-realm.json")
+  @WireMockStub("/wiremock/stubs/timer-call-targets.json")
+  void handleEntitlementEvent_positive_retriesWhileLiquibaseMigrationIsRunning() {
+    when(liquibaseMigrationLockService.isMigrationRunning()).thenReturn(true, false);
+
+    kafkaTemplate.send(ENTITLEMENT_EVENTS_TOPIC, asJsonString(entitlementEvent()));
+
+    await().atMost(TEN_SECONDS).pollDelay(ONE_HUNDRED_MILLISECONDS)
+      .untilAsserted(() -> {
+        checkTimerEnabled("123e4567-e89b-12d3-a456-426614174000", true);
+        checkTimerEnabled("123e4567-e89b-12d3-a456-426614174001", true);
+        checkTimerEnabled("123e4567-e89b-12d3-a456-426614174002", true);
+      });
+    await().untilAsserted(() -> verify(liquibaseMigrationLockService, atLeast(2)).isMigrationRunning());
   }
 
   private static void checkTimerEnabled(String id, boolean enabled) throws Exception {

--- a/src/test/java/org/folio/scheduler/it/KafkaMessageListenerScheduledJobIT.java
+++ b/src/test/java/org/folio/scheduler/it/KafkaMessageListenerScheduledJobIT.java
@@ -17,7 +17,10 @@ import static org.folio.scheduler.utils.TestUtils.parse;
 import static org.folio.scheduler.utils.TestUtils.readString;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.quartz.impl.matchers.GroupMatcher.anyJobGroup;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -39,6 +42,7 @@ import org.folio.scheduler.integration.kafka.model.ResourceEvent;
 import org.folio.scheduler.integration.kafka.model.ScheduledTimers;
 import org.folio.scheduler.service.SchedulerTimerService;
 import org.folio.scheduler.support.base.BaseIntegrationTest;
+import org.folio.spring.liquibase.LiquibaseMigrationLockService;
 import org.folio.test.extensions.EnableKeycloakTlsMode;
 import org.folio.test.extensions.KeycloakRealms;
 import org.folio.test.extensions.WireMockStub;
@@ -60,6 +64,7 @@ import org.springframework.dao.InvalidDataAccessResourceUsageException;
 import org.springframework.http.MediaType;
 import org.springframework.kafka.core.KafkaAdmin;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
@@ -75,6 +80,7 @@ class KafkaMessageListenerScheduledJobIT extends BaseIntegrationTest {
   private static final String MODULE_NAME = "mod-foo";
 
   @MockitoSpyBean private SchedulerTimerService schedulerTimerService;
+  @MockitoBean private LiquibaseMigrationLockService liquibaseMigrationLockService;
   @Autowired private Scheduler scheduler;
   @Autowired private KafkaTemplate<String, String> kafkaTemplate;
 
@@ -108,6 +114,19 @@ class KafkaMessageListenerScheduledJobIT extends BaseIntegrationTest {
 
     await().atMost(TWO_SECONDS).pollDelay(ONE_HUNDRED_MILLISECONDS)
       .untilAsserted(BaseIntegrationTest::verifyTimerRequestCallsCount);
+  }
+
+  @Test
+  @WireMockStub("/wiremock/stubs/timer-endpoint.json")
+  @KeycloakRealms("/json/keycloak/test-realm.json")
+  void handleScheduledJobEvent_positive_retriesWhileLiquibaseMigrationIsRunning() {
+    when(liquibaseMigrationLockService.isMigrationRunning()).thenReturn(true, false);
+
+    kafkaTemplate.send(SCHEDULED_TIMER_TOPIC, asJsonString(resourceEvent()));
+
+    await().untilAsserted(() -> getScheduledTimers(timerDescriptorList(timerDescriptor()))
+      .andExpect(jsonPath("$.timerDescriptors[0].id").hasJsonPath()));
+    await().untilAsserted(() -> verify(liquibaseMigrationLockService, atLeast(2)).isMigrationRunning());
   }
 
   @Test

--- a/src/test/java/org/folio/scheduler/it/SchedulerTimerIT.java
+++ b/src/test/java/org/folio/scheduler/it/SchedulerTimerIT.java
@@ -99,9 +99,10 @@ class SchedulerTimerIT extends BaseIntegrationTest {
     doPost("/scheduler/timers", timerDescriptor)
       .andExpect(jsonPath("$.id", notNullValue()))
       .andExpect(jsonPath("$.enabled", is(true)));
+    var timestampAfterSavingDesc = Instant.now();
 
     var nextFireTime = scheduler.getTrigger(triggerKey(timerId.toString())).getNextFireTime().toInstant();
-    assertThat(nextFireTime).isAfter(timestampBeforeSavingDesc).isBefore(timestampBeforeSavingDesc.plusSeconds(1));
+    assertThat(nextFireTime).isAfter(timestampBeforeSavingDesc).isBefore(timestampAfterSavingDesc.plusSeconds(1));
 
     await().atMost(TEN_SECONDS).pollDelay(ONE_SECOND)
       .untilAsserted(BaseIntegrationTest::verifyTimerRequestCallsCount);


### PR DESCRIPTION
### **Purpose**
Adds a guard in the Kafka message listeners to detect when a Liquibase migration is in progress before processing incoming events. Without this check, entitlement and scheduled-job events arriving during a migration could fail against an incomplete schema. Introduces retry-with-back-off behaviour for this condition, consistent with the existing table-not-found retry path.
https://folio-org.atlassian.net/browse/MODSCHED-74

### **Approach**
- Injected `LiquibaseMigrationLockService` into `KafkaMessageListener`; before processing `CREATE`/`UPDATE` resource events and `ENTITLE`/`UPGRADE` entitlement events, checks `isMigrationRunning()` and throws `LiquibaseMigrationException` if a migration is active
- Updated `KafkaConfiguration.getBackOff()` to detect `LiquibaseMigrationException` in the cause chain and apply a fixed back-off retry (reusing the same retry properties as the table-not-found path)
- Extracted `getFixedBackOff()` and `hasCause()` private helpers to eliminate duplication in the error-handler back-off logic
- Extended unit and integration tests to cover the Liquibase-migration guard for both listener entry points

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.