### PR TITLE
MODSCHED-83: Scheduled circulation events are not triggered

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 * Handle Liquibase migration state during Kafka event processing (MODSCHED-74)
 * Filter Kafka messages by tenant entitlements (MODSCHED-69)
 * Restrict public REST API mutations for SYSTEM timers (MODSCHED-71)
+* Retry user impersonation token retrieval and prevent scheduled timer calls without a valid token (MODSCHED-83)
 ---
 
 ## Version `v3.0.0` (12.03.2025)

--- a/README.md
+++ b/README.md
@@ -174,8 +174,16 @@ Two independent strategies control the behaviour:
 | SYSTEM_USER_MAX_DELAY             | 1m            | Maximum delay between attempts to retrieve system user                                                                                  |
 | SYSTEM_USER_RETRY_ATTEMPTS        | 2147483647    | Number of retry attempts to retrieve system user (default value is Long.MAX_VALUE ~= infinite amount of retries)                        |
 | SYSTEM_USER_RETRY_MULTIPLIER      | 1.5           | Retry attempts delay multiplier to retrieve system user                                                                                 |
+| USER_IMPERSONATION_RETRY_DELAY    | 1s            | Retry delay between attempts to obtain a user impersonation token for scheduled job execution                                           |
+| USER_IMPERSONATION_MAX_DELAY      | 1m            | Maximum delay between attempts to obtain a user impersonation token                                                                     |
+| USER_IMPERSONATION_RETRY_ATTEMPTS | 3             | Number of retry attempts to obtain a user impersonation token                                                                           |
+| USER_IMPERSONATION_RETRY_MULTIPLIER | 1.5           | Retry attempts delay multiplier to obtain a user impersonation token                                                                    |
 | SCHEDULED_TIMER_EVENT_RETRY_DELAY | 1s            | Retry delay between attempts to process event from `scheduled-job` Kafka topic                                                          |
 | SCHEDULED_TIMER_EVENT_ATTEMPTS    | 2147483647    | Number of attempts to process event from `scheduled-job` Kafka topic (default value is Integer.MAX_VALUE ~= infinite amount of retries) |
+
+Timer execution uses a Keycloak user impersonation token as `X-Okapi-Token`. If token exchange returns a blank,
+missing, or literal `null` token, the response is not cached and the impersonation request is retried according to
+the `USER_IMPERSONATION_*` settings. If a valid token still cannot be obtained, the timer request is not sent.
 
 ### Secure storage environment variables
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Two independent strategies control the behaviour:
 | SYSTEM_USER_RETRY_ATTEMPTS        | 2147483647    | Number of retry attempts to retrieve system user (default value is Long.MAX_VALUE ~= infinite amount of retries)                        |
 | SYSTEM_USER_RETRY_MULTIPLIER      | 1.5           | Retry attempts delay multiplier to retrieve system user                                                                                 |
 | USER_IMPERSONATION_RETRY_DELAY    | 1s            | Retry delay between attempts to obtain a user impersonation token for scheduled job execution                                           |
-| USER_IMPERSONATION_MAX_DELAY      | 1m            | Maximum delay between attempts to obtain a user impersonation token                                                                     |
+| USER_IMPERSONATION_MAX_DELAY      | 30s           | Maximum delay between attempts to obtain a user impersonation token                                                                     |
 | USER_IMPERSONATION_RETRY_ATTEMPTS | 3             | Number of retry attempts to obtain a user impersonation token                                                                           |
 | USER_IMPERSONATION_RETRY_MULTIPLIER | 1.5           | Retry attempts delay multiplier to obtain a user impersonation token                                                                    |
 | SCHEDULED_TIMER_EVENT_RETRY_DELAY | 1s            | Retry delay between attempts to process event from `scheduled-job` Kafka topic                                                          |

--- a/src/main/java/org/folio/scheduler/integration/keycloak/KeycloakUserImpersonationService.java
+++ b/src/main/java/org/folio/scheduler/integration/keycloak/KeycloakUserImpersonationService.java
@@ -6,6 +6,8 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.keycloak.OAuth2Constants.TOKEN_EXCHANGE_GRANT_TYPE;
 
 import com.github.benmanes.caffeine.cache.Cache;
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.ServerErrorException;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import lombok.RequiredArgsConstructor;
@@ -36,7 +38,7 @@ public class KeycloakUserImpersonationService implements UserImpersonationServic
       maxDelayExpression = "#{@retryConfigurationProperties.config['user-impersonation'].maxDelay.toMillis()}",
       multiplierExpression = "#{@retryConfigurationProperties.config['user-impersonation'].retryMultiplier}"
     ),
-    retryFor = {RuntimeException.class},
+    retryFor = {InvalidUserImpersonationTokenException.class, ProcessingException.class, ServerErrorException.class},
     listeners = "methodLoggingRetryListener")
   public String impersonate(String tenant, String userId) {
     var key = buildCacheKey(tenant, userId);
@@ -77,9 +79,16 @@ public class KeycloakUserImpersonationService implements UserImpersonationServic
     var token = response == null ? null : response.getToken();
     if (isBlank(token) || "null".equalsIgnoreCase(token.trim())) {
       tokenCache.invalidate(buildCacheKey(tenant, userId));
-      throw new IllegalStateException("Failed to obtain user impersonation token: token is blank [tenant: "
-        + tenant + ", userId: " + userId + "]");
+      throw new InvalidUserImpersonationTokenException("Failed to obtain user impersonation token: token is blank "
+        + "[tenant: " + tenant + ", userId: " + userId + "]");
     }
     return token;
+  }
+
+  private static final class InvalidUserImpersonationTokenException extends IllegalStateException {
+
+    private InvalidUserImpersonationTokenException(String message) {
+      super(message);
+    }
   }
 }

--- a/src/main/java/org/folio/scheduler/integration/keycloak/KeycloakUserImpersonationService.java
+++ b/src/main/java/org/folio/scheduler/integration/keycloak/KeycloakUserImpersonationService.java
@@ -2,6 +2,7 @@ package org.folio.scheduler.integration.keycloak;
 
 import static java.net.URI.create;
 import static java.util.Collections.singletonList;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.keycloak.OAuth2Constants.TOKEN_EXCHANGE_GRANT_TYPE;
 
 import com.github.benmanes.caffeine.cache.Cache;
@@ -14,6 +15,8 @@ import org.folio.scheduler.service.UserImpersonationService;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.token.TokenService;
 import org.keycloak.representations.AccessTokenResponse;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 
 @Log4j2
 @RequiredArgsConstructor
@@ -26,15 +29,26 @@ public class KeycloakUserImpersonationService implements UserImpersonationServic
   private final Cache<String, AccessTokenResponse> tokenCache;
 
   @Override
+  @Retryable(
+    maxAttemptsExpression = "#{@retryConfigurationProperties.config['user-impersonation'].retryAttempts}",
+    backoff = @Backoff(
+      delayExpression = "#{@retryConfigurationProperties.config['user-impersonation'].retryDelay.toMillis()}",
+      maxDelayExpression = "#{@retryConfigurationProperties.config['user-impersonation'].maxDelay.toMillis()}",
+      multiplierExpression = "#{@retryConfigurationProperties.config['user-impersonation'].retryMultiplier}"
+    ),
+    retryFor = {RuntimeException.class},
+    listeners = "methodLoggingRetryListener")
   public String impersonate(String tenant, String userId) {
     var key = buildCacheKey(tenant, userId);
     var accessTokenResponse = tokenCache.getIfPresent(key);
     if (accessTokenResponse == null) {
       accessTokenResponse = getUserToken(tenant, userId);
+      var token = accessToken(accessTokenResponse, tenant, userId);
       tokenCache.put(key, accessTokenResponse);
       log.debug("Update cache with user token: tenant = {}, userId = {}", tenant, userId);
+      return token;
     }
-    return accessTokenResponse.getToken();
+    return accessToken(accessTokenResponse, tenant, userId);
   }
 
   private AccessTokenResponse getUserToken(String tenant, String userId) {
@@ -57,5 +71,15 @@ public class KeycloakUserImpersonationService implements UserImpersonationServic
 
   private static String buildCacheKey(String tenant, String userId) {
     return tenant + ":" + userId;
+  }
+
+  private String accessToken(AccessTokenResponse response, String tenant, String userId) {
+    var token = response == null ? null : response.getToken();
+    if (isBlank(token) || "null".equalsIgnoreCase(token.trim())) {
+      tokenCache.invalidate(buildCacheKey(tenant, userId));
+      throw new IllegalStateException("Failed to obtain user impersonation token: token is blank [tenant: "
+        + tenant + ", userId: " + userId + "]");
+    }
+    return token;
   }
 }

--- a/src/main/java/org/folio/scheduler/integration/keycloak/KeycloakUserService.java
+++ b/src/main/java/org/folio/scheduler/integration/keycloak/KeycloakUserService.java
@@ -36,17 +36,18 @@ public class KeycloakUserService {
   public String findUserIdByKeycloakUsername(String realm, String username) {
     var foundUsers = keycloak.realm(realm).users().searchByUsername(username, true);
     if (isEmpty(foundUsers)) {
-      throw new NotFoundException("Keycloak user doesn't exist with the given username: " + username);
+      throw new NotFoundException("Keycloak user doesn't exist with the given username: " + username
+        + " [tenant: " + realm + "]");
     }
 
-    var keycloakUser = foundUsers.get(0);
+    var keycloakUser = foundUsers.getFirst();
     var userIdAttributes = MapUtils.emptyIfNull(keycloakUser.getAttributes()).get(USER_ID_ATTR);
     if (isEmpty(userIdAttributes)) {
       throw new NotFoundException(format(
         "%s attribute is not found in user with username: %s", USER_ID_ATTR, username));
     }
 
-    return userIdAttributes.get(0);
+    return userIdAttributes.getFirst();
   }
 
   private UserRepresentation findKeycloakUser(String tenant, String userId) {
@@ -54,12 +55,13 @@ public class KeycloakUserService {
     refreshTokenIfExists();
     var keycloakUser = keycloak.realm(tenant).users().searchByAttributes(query);
     if (isEmpty(keycloakUser)) {
-      throw new NotFoundException("Keycloak user doesn't exist with the given 'user_id' attribute: " + userId);
+      throw new NotFoundException("Keycloak user doesn't exist with the given 'user_id' attribute: " + userId
+        + " [tenant: " + tenant + "]");
     }
     if (keycloakUser.size() != 1) {
       throw new IllegalStateException("Too many keycloak users with 'user_id' attribute: " + userId);
     }
-    return keycloakUser.get(0);
+    return keycloakUser.getFirst();
   }
 
   private void refreshTokenIfExists() {

--- a/src/main/java/org/folio/scheduler/service/jobs/OkapiHttpRequestExecutor.java
+++ b/src/main/java/org/folio/scheduler/service/jobs/OkapiHttpRequestExecutor.java
@@ -4,6 +4,7 @@ import static java.util.Collections.singletonList;
 import static java.util.Map.entry;
 import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.folio.common.utils.OkapiHeaders.USER_ID;
 import static org.folio.spring.integration.XOkapiHeaders.REQUEST_ID;
@@ -136,12 +137,21 @@ public class OkapiHttpRequestExecutor implements Job {
     var headers = new HashMap<String, Collection<String>>();
     var tenant = (String) jobDataMap.get(TENANT);
     var userId = getUserId(jobDataMap, tenant);
+    var userToken = userImpersonationService.impersonate(tenant, userId);
+    validateUserToken(userToken, tenant, userId);
 
     headers.put(URL, singletonList(okapiConfigurationProperties.getUrl()));
-    headers.put(TOKEN, singletonList(userImpersonationService.impersonate(tenant, userId)));
+    headers.put(TOKEN, singletonList(userToken));
     headers.put(REQUEST_ID, singletonList(String.format("%06d", current().nextInt(1000000))));
     headers.put(TENANT, singletonList(tenant));
     return headers;
+  }
+
+  private static void validateUserToken(String userToken, String tenant, String userId) {
+    if (isBlank(userToken) || "null".equalsIgnoreCase(userToken.trim())) {
+      throw new IllegalStateException("Failed to prepare timer request: user impersonation token is blank [tenant: "
+        + tenant + ", userId: " + userId + "]");
+    }
   }
 
   private String getUserId(JobDataMap jobDataMap, String tenant) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -116,6 +116,11 @@ application:
         max-delay: ${SYSTEM_USER_MAX_DELAY:1m}
         retry-attempts: ${SYSTEM_USER_RETRY_ATTEMPTS:2147483647}
         retry-multiplier: ${SYSTEM_USER_RETRY_MULTIPLIER:1.5}
+      user-impersonation:
+        retry-delay: ${USER_IMPERSONATION_RETRY_DELAY:1s}
+        max-delay: ${USER_IMPERSONATION_MAX_DELAY:30s}
+        retry-attempts: ${USER_IMPERSONATION_RETRY_ATTEMPTS:3}
+        retry-multiplier: ${USER_IMPERSONATION_RETRY_MULTIPLIER:1.5}
       scheduled-timer-event:
         retry-delay: ${SCHEDULED_TIMER_EVENT_RETRY_DELAY:1s}
         retry-attempts: ${SCHEDULED_TIMER_EVENT_ATTEMPTS:2147483647}

--- a/src/test/java/org/folio/scheduler/integration/keycloak/KeycloakUserImpersonationServiceTest.java
+++ b/src/test/java/org/folio/scheduler/integration/keycloak/KeycloakUserImpersonationServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
@@ -22,6 +23,7 @@ import org.folio.scheduler.configuration.properties.RetryConfigurationProperties
 import org.folio.scheduler.integration.keycloak.KeycloakUserImpersonationServiceTest.TestContextConfiguration;
 import org.folio.scheduler.integration.keycloak.configuration.properties.KeycloakProperties;
 import org.folio.scheduler.service.UserImpersonationService;
+import org.folio.spring.exception.NotFoundException;
 import org.folio.test.types.UnitTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -140,6 +142,25 @@ class KeycloakUserImpersonationServiceTest {
       verify(tokenCache).invalidate(cacheKey());
       verify(tokenCache).put(cacheKey(), accessTokenResponse);
       verify(tokenService).grantToken(eq(TENANT_ID), any());
+    }
+
+    @Test
+    void impersonate_negative_userNotFoundIsNotRetried() {
+      when(properties.getBaseUrl()).thenReturn(BASE_URL);
+      when(properties.getImpersonationClient()).thenReturn(IMPERSONATION_CLIENT);
+      when(clientSecretService.retrieveSecretFromSecretStore(TENANT_ID, IMPERSONATION_CLIENT))
+        .thenReturn("clientSecret");
+      when(keycloak.proxy(TokenService.class, URI.create(BASE_URL))).thenReturn(tokenService);
+      when(userService.findKeycloakIdByTenantAndUserId(TENANT_ID, USER_ID))
+        .thenThrow(new NotFoundException("missing user"));
+
+      assertThatThrownBy(() -> service.impersonate(TENANT_ID, USER_ID))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessage("missing user");
+
+      verify(tokenCache).getIfPresent(cacheKey());
+      verify(userService).findKeycloakIdByTenantAndUserId(TENANT_ID, USER_ID);
+      verifyNoInteractions(tokenService);
     }
   }
 

--- a/src/test/java/org/folio/scheduler/integration/keycloak/KeycloakUserImpersonationServiceTest.java
+++ b/src/test/java/org/folio/scheduler/integration/keycloak/KeycloakUserImpersonationServiceTest.java
@@ -1,33 +1,45 @@
 package org.folio.scheduler.integration.keycloak;
 
+import static java.time.Duration.ofMillis;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.folio.scheduler.support.TestConstants.TENANT_ID;
 import static org.folio.scheduler.support.TestConstants.USER_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import java.net.URI;
+import java.util.Map;
+import org.folio.scheduler.configuration.RetryConfiguration;
+import org.folio.scheduler.configuration.properties.RetryConfigurationProperties;
+import org.folio.scheduler.configuration.properties.RetryConfigurationProperties.RetryProperties;
+import org.folio.scheduler.integration.keycloak.KeycloakUserImpersonationServiceTest.TestContextConfiguration;
 import org.folio.scheduler.integration.keycloak.configuration.properties.KeycloakProperties;
+import org.folio.scheduler.service.UserImpersonationService;
 import org.folio.test.types.UnitTest;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.token.TokenService;
 import org.keycloak.representations.AccessTokenResponse;
-import org.mockito.Answers;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @UnitTest
-@ExtendWith(MockitoExtension.class)
+@SpringBootTest(
+  classes = {KeycloakUserImpersonationService.class, TestContextConfiguration.class},
+  webEnvironment = NONE)
 class KeycloakUserImpersonationServiceTest {
 
   private static final String KEYCLOAK_USER_ID = "00000000-0000-0000-0000-000000000002";
@@ -35,40 +47,113 @@ class KeycloakUserImpersonationServiceTest {
   private static final String TOKEN = "token";
   private static final String IMPERSONATION_CLIENT = "impersonation-client";
 
-  @InjectMocks private KeycloakUserImpersonationService service;
-  @Mock private Keycloak keycloak;
-  @Mock private KeycloakUserService userService;
-  @Mock(answer = Answers.RETURNS_DEEP_STUBS) private KeycloakProperties properties;
-  @Mock private TokenService tokenService;
-  @Mock private ClientSecretService clientSecretService;
-  @Mock private Cache<String, AccessTokenResponse> tokenCache;
+  @Autowired private UserImpersonationService service;
+  @MockitoBean private Keycloak keycloak;
+  @MockitoBean private KeycloakUserService userService;
+  @MockitoBean private KeycloakProperties properties;
+  @MockitoBean private TokenService tokenService;
+  @MockitoBean private ClientSecretService clientSecretService;
+  @MockitoBean private Cache<String, AccessTokenResponse> tokenCache;
 
-  @AfterEach
-  void afterAll() {
-    verifyNoMoreInteractions(keycloak, userService);
+  private void mockTokenRequest() {
+    when(properties.getBaseUrl()).thenReturn(BASE_URL);
+    when(properties.getImpersonationClient()).thenReturn(IMPERSONATION_CLIENT);
+    when(clientSecretService.retrieveSecretFromSecretStore(TENANT_ID, IMPERSONATION_CLIENT))
+      .thenReturn("clientSecret");
+    when(keycloak.proxy(TokenService.class, URI.create(BASE_URL))).thenReturn(tokenService);
+    when(userService.findKeycloakIdByTenantAndUserId(TENANT_ID, USER_ID)).thenReturn(KEYCLOAK_USER_ID);
+  }
+
+  private static AccessTokenResponse tokenResponse(String token) {
+    var accessTokenResponse = new AccessTokenResponse();
+    accessTokenResponse.setToken(token);
+    return accessTokenResponse;
+  }
+
+  private static String cacheKey() {
+    return TENANT_ID + ":" + USER_ID;
+  }
+
+  private static String invalidTokenMessage() {
+    return "Failed to obtain user impersonation token: token is blank [tenant: test, userId: " + USER_ID + "]";
   }
 
   @Nested
   class Impersonate {
 
     @Test
-    void positive() {
-      var accessTokenResponse = new AccessTokenResponse();
-      accessTokenResponse.setToken(TOKEN);
-
-      when(properties.getBaseUrl()).thenReturn(BASE_URL);
-      when(properties.getImpersonationClient()).thenReturn(IMPERSONATION_CLIENT);
-      when(clientSecretService.retrieveSecretFromSecretStore(TENANT_ID, IMPERSONATION_CLIENT))
-        .thenReturn("clientSecret");
-      when(keycloak.proxy(TokenService.class, URI.create(properties.getBaseUrl()))).thenReturn(tokenService);
+    void impersonate_positive_tokenIsCached() {
+      var accessTokenResponse = tokenResponse(TOKEN);
+      mockTokenRequest();
       when(tokenService.grantToken(eq(TENANT_ID), any())).thenReturn(accessTokenResponse);
-      when(userService.findKeycloakIdByTenantAndUserId(TENANT_ID, USER_ID)).thenReturn(KEYCLOAK_USER_ID);
 
       var token = service.impersonate(TENANT_ID, USER_ID);
+
       assertThat(token).isEqualTo(TOKEN);
-      var cacheKey = TENANT_ID + ":" + USER_ID;
-      verify(tokenCache).getIfPresent(cacheKey);
-      verify(tokenCache).put(eq(cacheKey), isA(AccessTokenResponse.class));
+      verify(tokenCache).getIfPresent(cacheKey());
+      verify(tokenCache).put(cacheKey(), accessTokenResponse);
+    }
+
+    @Test
+    void impersonate_positive_retryIsUsedForBlankTokenResponse() {
+      var accessTokenResponse = tokenResponse(TOKEN);
+      mockTokenRequest();
+      when(tokenService.grantToken(eq(TENANT_ID), any()))
+        .thenReturn(tokenResponse(null))
+        .thenReturn(accessTokenResponse);
+
+      var token = service.impersonate(TENANT_ID, USER_ID);
+
+      assertThat(token).isEqualTo(TOKEN);
+      verify(tokenCache, times(2)).getIfPresent(cacheKey());
+      verify(tokenCache).put(cacheKey(), accessTokenResponse);
+      verify(tokenService, times(2)).grantToken(eq(TENANT_ID), any());
+    }
+
+    @Test
+    void impersonate_negative_emptyTokenResponseIsNotCached() {
+      mockTokenRequest();
+      when(tokenService.grantToken(eq(TENANT_ID), any())).thenReturn(tokenResponse(""));
+
+      assertThatThrownBy(() -> service.impersonate(TENANT_ID, USER_ID))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(invalidTokenMessage());
+
+      verify(tokenCache, times(3)).getIfPresent(cacheKey());
+      verify(tokenCache, never()).put(any(), any());
+      verify(tokenService, times(3)).grantToken(eq(TENANT_ID), any());
+    }
+
+    @Test
+    void impersonate_positive_cachedInvalidTokenIsEvictedAndRetried() {
+      var accessTokenResponse = tokenResponse(TOKEN);
+      when(tokenCache.getIfPresent(cacheKey()))
+        .thenReturn(tokenResponse("null"))
+        .thenReturn(null);
+      mockTokenRequest();
+      when(tokenService.grantToken(eq(TENANT_ID), any())).thenReturn(accessTokenResponse);
+
+      var token = service.impersonate(TENANT_ID, USER_ID);
+
+      assertThat(token).isEqualTo(TOKEN);
+      verify(tokenCache, times(2)).getIfPresent(cacheKey());
+      verify(tokenCache).invalidate(cacheKey());
+      verify(tokenCache).put(cacheKey(), accessTokenResponse);
+      verify(tokenService).grantToken(eq(TENANT_ID), any());
+    }
+  }
+
+  @EnableRetry
+  @TestConfiguration
+  @Import(RetryConfiguration.class)
+  static class TestContextConfiguration {
+
+    @Bean
+    RetryConfigurationProperties retryConfigurationProperties() {
+      var configuration = new RetryConfigurationProperties();
+      configuration.setConfig(Map.of("user-impersonation",
+        RetryProperties.of(ofMillis(10), ofMillis(100), 3, 1.5)));
+      return configuration;
     }
   }
 }

--- a/src/test/java/org/folio/scheduler/integration/keycloak/KeycloakUserServiceTest.java
+++ b/src/test/java/org/folio/scheduler/integration/keycloak/KeycloakUserServiceTest.java
@@ -79,7 +79,7 @@ class KeycloakUserServiceTest {
 
       assertThatThrownBy(() -> service.findUserIdByKeycloakUsername(TENANT_ID, USERNAME))
         .isInstanceOf(NotFoundException.class)
-        .hasMessage("Keycloak user doesn't exist with the given username: test-username");
+        .hasMessage("Keycloak user doesn't exist with the given username: test-username [tenant: test]");
     }
   }
 
@@ -112,8 +112,10 @@ class KeycloakUserServiceTest {
 
       assertThrows(IllegalStateException.class, () -> service.findKeycloakIdByTenantAndUserId(TENANT_ID, USER_ID),
         "Too many keycloak users with 'user_id' attribute: " + USER_ID);
-      assertThrows(NotFoundException.class, () -> service.findKeycloakIdByTenantAndUserId(TENANT_ID, USER_ID),
-        "Keycloak user doesn't exist with the given 'user_id' attribute: " + USER_ID);
+      assertThatThrownBy(() -> service.findKeycloakIdByTenantAndUserId(TENANT_ID, USER_ID))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessage("Keycloak user doesn't exist with the given 'user_id' attribute: "
+          + USER_ID + " [tenant: test]");
     }
   }
 }

--- a/src/test/java/org/folio/scheduler/service/jobs/OkapiHttpRequestExecutorTest.java
+++ b/src/test/java/org/folio/scheduler/service/jobs/OkapiHttpRequestExecutorTest.java
@@ -1,6 +1,7 @@
 package org.folio.scheduler.service.jobs;
 
 import static java.util.Optional.of;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.folio.scheduler.support.TestConstants.TENANT_ID;
 import static org.folio.scheduler.support.TestConstants.TIMER_ID;
 import static org.folio.scheduler.support.TestConstants.TIMER_UUID;
@@ -32,6 +33,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -71,18 +75,19 @@ class OkapiHttpRequestExecutorTest {
       okapiClient, jobExecutionContext, schedulerTimerService, okapiConfigurationProperties);
   }
 
-  @Test
-  void execute_positive_userTokenIsNull() {
-    var re = new RoutingEntry().methods(List.of("GET")).pathPattern("/test-endpoint");
-    when(folioModuleMetadata.getModuleName()).thenReturn(MODULE_NAME);
-    when(okapiConfigurationProperties.getUrl()).thenReturn(OKAPI_URL);
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {" ", "null", " NULL "})
+  void execute_negative_userTokenIsBlank(String userToken) {
     when(jobExecutionContext.getJobDetail()).thenReturn(jobDetail());
-    when(schedulerTimerService.findById(TIMER_UUID)).thenReturn(of(timerDescriptor(re)));
-    when(userImpersonationService.impersonate(TENANT_ID, TestConstants.USER_ID)).thenReturn(null);
+    when(userImpersonationService.impersonate(TENANT_ID, TestConstants.USER_ID)).thenReturn(userToken);
 
-    job.execute(jobExecutionContext);
+    assertThatThrownBy(() -> job.execute(jobExecutionContext))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("Failed to prepare timer request: user impersonation token is blank [tenant: test, userId: "
+        + TestConstants.USER_ID + "]");
 
-    verify(okapiClient).doGet(fromUriString("http://test-endpoint").build().toUri(), TEST_MODULE_ID);
+    verifyNoInteractions(okapiClient, schedulerTimerService);
   }
 
   @Test

--- a/src/test/resources/application-it.yml
+++ b/src/test/resources/application-it.yml
@@ -47,6 +47,11 @@ application:
         max-delay: 250ms
         retry-attempts: 5
         retry-multiplier: 1.5
+      user-impersonation:
+        retry-delay: 100ms
+        max-delay: 250ms
+        retry-attempts: 3
+        retry-multiplier: 1.5
   keycloak:
     admin:
       client-id: folio-backend-admin-client


### PR DESCRIPTION
### **Purpose**
Prevent scheduled timer calls from being sent without a valid `X-Okapi-Token`.

Related issue: https://folio-org.atlassian.net/browse/CIRC-2609

### **Approach**
Added retry and validation around Keycloak user impersonation token retrieval. Invalid token responses are not cached, cached invalid tokens are evicted, and timer execution now fails before sending the request if no valid token can be obtained.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [x] **New Properties / Environment Variables** — Updated README.md if new configs were added.