### PR TITLE
MODSCHED-84: Upgrade dependencies for Kafka 4.2 compatibility in mod-scheduler

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## Version `v4.1.0` (In Progress)
+### Changes:
+* Upgrade dependencies for Kafka 4.2 compatibility in mod-scheduler (MODSCHED-84)
+---
+
 ## Version `v4.0.0` (17.04.2026)
 ### Changes:
 * Normalize cron notation to the Quartz format (MODSCHED-33)

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,9 @@
     <mod-scheduler.yaml-file>${project.basedir}/src/main/resources/swagger.api/mod-scheduler.yaml
     </mod-scheduler.yaml-file>
 
+    <!-- overrides Spring Boot BOM default; can be removed once Spring Boot ships this version -->
+    <kafka.version>4.2.0</kafka.version>
+
     <!-- Test dependencies versions -->
     <mockito.version>5.23.0</mockito.version>
     <awaitility.version>4.3.0</awaitility.version>


### PR DESCRIPTION
### **Purpose**
Fix [MODSCHED-84](https://folio-org.atlassian.net/browse/MODSCHED-84)

### **Approach**
Add to pom - `<kafka.version>4.2.0</kafka.version>`
After the change, kafka version is correctly shown in the effective pom
<img width="930" height="560" alt="image" src="https://github.com/user-attachments/assets/b4b1b8a9-8719-4ef5-81de-c9b5b197b683" />


---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
