### PR TITLE
MODSCHED-88: Add timer CQL query support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # mod-scheduler
 
-Spring Boot 3.5.7 microservice (Java 21) providing scheduled job execution for FOLIO. Quartz Scheduler for jobs, Kafka for event-driven provisioning, Keycloak for auth, PostgreSQL/Liquibase.
+Spring Boot 4.1.0 microservice (Java 21) providing scheduled job execution for FOLIO. Quartz Scheduler for jobs, Kafka for event-driven provisioning, Keycloak for auth, PostgreSQL/Liquibase.
 
 ## Build & Test
 
@@ -38,7 +38,7 @@ Run locally needs PostgreSQL + env (`DB_*`, `okapi.url`); Docker build `docker b
 
 ## Key Patterns
 
-- **Natural-key dedup**: `{TYPE}#{MODULE_NAME}#{METHODS}#{PATH}` (e.g. `SYSTEM#mod-foo#POST#/timers`).
+- **Natural-key dedup**: `{type}#{moduleName}#{methods}#{path}` — runtime lowercases the type (e.g. `system#mod-foo#POST#/timers`); legacy migration-`07` rows use an uppercase `SYSTEM#…` prefix, a known case mismatch vs the case-sensitive `natural_key_index` (see MODSCHED-88).
 - **JSONB queries**: native PG JSONB operators in `@Query`.
 - **Retry**: Spring Retry w/ exponential backoff (`SYSTEM_USER_RETRY_*`, `SCHEDULED_TIMER_EVENT_*`).
 - **Caching**: Caffeine TTL — Keycloak/system-user IDs (30m), client secrets (6000s), tokens (refresh 25s before expiry).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## Version `v4.1.0` (In Progress)
 ### Changes:
 * Upgrade dependencies for Kafka 4.2 compatibility in mod-scheduler (MODSCHED-84)
+* Add CQL filtering support for scheduler timers (MODSCHED-88)
 ---
 
 ## Version `v4.0.0` (17.04.2026)

--- a/src/main/java/org/folio/scheduler/controller/SchedulerTimerController.java
+++ b/src/main/java/org/folio/scheduler/controller/SchedulerTimerController.java
@@ -36,8 +36,8 @@ public class SchedulerTimerController implements SchedulerApi {
   }
 
   @Override
-  public ResponseEntity<TimerDescriptorList> getSchedulerTimers(Integer offset, Integer limit) {
-    var result = schedulerTimerService.getAll(offset, limit);
+  public ResponseEntity<TimerDescriptorList> getSchedulerTimers(String query, Integer offset, Integer limit) {
+    var result = schedulerTimerService.getAll(query, offset, limit);
     return ResponseEntity.ok(new TimerDescriptorList()
       .timerDescriptors(result.getRecords())
       .totalRecords(result.getTotalRecords()));

--- a/src/main/java/org/folio/scheduler/repository/SchedulerTimerRepository.java
+++ b/src/main/java/org/folio/scheduler/repository/SchedulerTimerRepository.java
@@ -7,14 +7,14 @@ import java.util.Optional;
 import java.util.UUID;
 import org.folio.scheduler.domain.entity.TimerDescriptorEntity;
 import org.folio.scheduler.domain.model.TimerType;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.folio.spring.cql.JpaCqlRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface SchedulerTimerRepository extends JpaRepository<TimerDescriptorEntity, UUID> {
+public interface SchedulerTimerRepository extends JpaCqlRepository<TimerDescriptorEntity, UUID> {
 
   List<TimerDescriptorEntity> findByModuleNameAndType(String moduleName, TimerType type);
 

--- a/src/main/java/org/folio/scheduler/service/SchedulerTimerService.java
+++ b/src/main/java/org/folio/scheduler/service/SchedulerTimerService.java
@@ -1,6 +1,7 @@
 package org.folio.scheduler.service;
 
 import static java.util.Objects.requireNonNullElseGet;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.folio.common.utils.CollectionUtils.mapItems;
 import static org.folio.scheduler.utils.TimerDescriptorUtils.evalModuleName;
@@ -72,9 +73,10 @@ public class SchedulerTimerService {
    * @return saved {@link TimerDescriptor} object
    */
   @Transactional(readOnly = true)
-  public SearchResult<TimerDescriptor> getAll(Integer offset, Integer limit) {
-    return SearchResult.of(repository.findAll(OffsetRequest.of(offset, limit)).stream()
-      .map(mapper::toDescriptor).toList());
+  public SearchResult<TimerDescriptor> getAll(String query, Integer offset, Integer limit) {
+    var offsetRequest = OffsetRequest.of(offset, limit);
+    var page = isBlank(query) ? repository.findAll(offsetRequest) : repository.findByCql(query, offsetRequest);
+    return SearchResult.of((int) page.getTotalElements(), page.map(mapper::toDescriptor).getContent());
   }
 
   /**

--- a/src/main/resources/swagger.api/mod-scheduler.yaml
+++ b/src/main/resources/swagger.api/mod-scheduler.yaml
@@ -15,6 +15,7 @@ paths:
       operationId: getSchedulerTimers
       description: Retrieve timer list
       parameters:
+        - $ref: '#/components/parameters/cql-query'
         - $ref: '#/components/parameters/query-offset'
         - $ref: '#/components/parameters/query-limit'
       responses:
@@ -158,3 +159,13 @@ components:
         type: integer
         minimum: 0
         default: 0
+    cql-query:
+      in: query
+      required: false
+      name: query
+      description: >
+        A CQL query string with search conditions. Supported timer fields: moduleName, moduleId, type.
+        The type field uses USER or SYSTEM values. Fields stored only in timerDescriptor JSON, such as enabled,
+        are not supported.
+      schema:
+        type: string

--- a/src/test/java/org/folio/scheduler/controller/SchedulerTimerControllerTest.java
+++ b/src/test/java/org/folio/scheduler/controller/SchedulerTimerControllerTest.java
@@ -90,8 +90,26 @@ class SchedulerTimerControllerTest {
     var timerDescriptors = SearchResult.of(
       List.of(new TimerDescriptor().id(TIMER_UUID), new TimerDescriptor().id(randomUUID())));
 
-    when(schedulingTimerService.getAll(0, 10)).thenReturn(timerDescriptors);
+    when(schedulingTimerService.getAll(null, 0, 10)).thenReturn(timerDescriptors);
     var mvcResult = mockMvc.perform(get("/scheduler/timers")
+        .contentType(APPLICATION_JSON))
+      .andExpect(status().isOk())
+      .andReturn();
+
+    var actual = parseResponse(mvcResult, TimerDescriptorList.class);
+    assertThat(actual).isEqualTo(new TimerDescriptorList()
+      .timerDescriptors(timerDescriptors.getRecords())
+      .totalRecords(timerDescriptors.getTotalRecords()));
+  }
+
+  @Test
+  void get_all_positive_query() throws Exception {
+    var query = "moduleName==mod-foo";
+    var timerDescriptors = SearchResult.of(List.of(new TimerDescriptor().id(TIMER_UUID)));
+
+    when(schedulingTimerService.getAll(query, 0, 10)).thenReturn(timerDescriptors);
+    var mvcResult = mockMvc.perform(get("/scheduler/timers")
+        .queryParam("query", query)
         .contentType(APPLICATION_JSON))
       .andExpect(status().isOk())
       .andReturn();

--- a/src/test/java/org/folio/scheduler/it/KafkaMessageListenerEntitlementEventsIT.java
+++ b/src/test/java/org/folio/scheduler/it/KafkaMessageListenerEntitlementEventsIT.java
@@ -75,10 +75,11 @@ class KafkaMessageListenerEntitlementEventsIT extends BaseIntegrationTest {
         checkTimerEnabled("123e4567-e89b-12d3-a456-426614174000", true);
         checkTimerEnabled("123e4567-e89b-12d3-a456-426614174001", true);
         checkTimerEnabled("123e4567-e89b-12d3-a456-426614174002", true);
+        checkTimerEnabled("123e4567-e89b-12d3-a456-426614174003", true);
       });
-    // Two jobs must be added because one time was already enabled and thus didn't change
+    // Three jobs must be added because one timer was already enabled and thus didn't change.
     await().atMost(TEN_SECONDS).pollDelay(ONE_HUNDRED_MILLISECONDS)
-      .untilAsserted(() -> assertThat(scheduler.getJobKeys(anyJobGroup())).hasSize(2));
+      .untilAsserted(() -> assertThat(scheduler.getJobKeys(anyJobGroup())).hasSize(3));
 
     kafkaTemplate.send(ENTITLEMENT_EVENTS_TOPIC, asJsonString(entitlementEvent().setType(REVOKE)));
     await().atMost(TEN_SECONDS).pollDelay(ONE_HUNDRED_MILLISECONDS)
@@ -86,6 +87,7 @@ class KafkaMessageListenerEntitlementEventsIT extends BaseIntegrationTest {
         checkTimerEnabled("123e4567-e89b-12d3-a456-426614174000", false);
         checkTimerEnabled("123e4567-e89b-12d3-a456-426614174001", false);
         checkTimerEnabled("123e4567-e89b-12d3-a456-426614174002", false);
+        checkTimerEnabled("123e4567-e89b-12d3-a456-426614174003", false);
       });
     await().atMost(TEN_SECONDS).pollDelay(ONE_HUNDRED_MILLISECONDS)
       .untilAsserted(() -> assertThat(scheduler.getJobKeys(anyJobGroup())).isEmpty());
@@ -104,6 +106,7 @@ class KafkaMessageListenerEntitlementEventsIT extends BaseIntegrationTest {
         checkTimerEnabled("123e4567-e89b-12d3-a456-426614174000", true);
         checkTimerEnabled("123e4567-e89b-12d3-a456-426614174001", true);
         checkTimerEnabled("123e4567-e89b-12d3-a456-426614174002", true);
+        checkTimerEnabled("123e4567-e89b-12d3-a456-426614174003", true);
       });
     await().untilAsserted(() -> verify(liquibaseMigrationLockService, atLeast(2)).isMigrationRunning());
   }

--- a/src/test/java/org/folio/scheduler/it/SchedulerTimerIT.java
+++ b/src/test/java/org/folio/scheduler/it/SchedulerTimerIT.java
@@ -91,6 +91,42 @@ class SchedulerTimerIT extends BaseIntegrationTest {
   }
 
   @Test
+  void getAll_positive_queryByModuleName() throws Exception {
+    doGet("/scheduler/timers?query=moduleName==mod-foo")
+      .andExpect(jsonPath("$.totalRecords", is(4)))
+      .andExpect(jsonPath("$.timerDescriptors", hasSize(4)));
+  }
+
+  @Test
+  void getAll_positive_queryByModuleId() throws Exception {
+    doGet("/scheduler/timers?query=moduleId==mod-foo-1.0.0")
+      .andExpect(jsonPath("$.totalRecords", is(4)))
+      .andExpect(jsonPath("$.timerDescriptors", hasSize(4)));
+  }
+
+  @Test
+  void getAll_positive_queryByType() throws Exception {
+    doGet("/scheduler/timers?query=type==SYSTEM")
+      .andExpect(jsonPath("$.totalRecords", is(1)))
+      .andExpect(jsonPath("$.timerDescriptors", hasSize(1)))
+      .andExpect(jsonPath("$.timerDescriptors[0].id", is(SYSTEM_TIMER_ID)));
+  }
+
+  @Test
+  void getAll_positive_combinedQuery() throws Exception {
+    doGet("/scheduler/timers?query=moduleName==mod-foo and type==SYSTEM")
+      .andExpect(jsonPath("$.totalRecords", is(1)))
+      .andExpect(jsonPath("$.timerDescriptors", hasSize(1)))
+      .andExpect(jsonPath("$.timerDescriptors[0].id", is(SYSTEM_TIMER_ID)));
+  }
+
+  @Test
+  void getAll_negative_queryByEnabledIsUnsupported() throws Exception {
+    attemptGet("/scheduler/timers?query=enabled==true")
+      .andExpect(status().isBadRequest());
+  }
+
+  @Test
   @WireMockStub("/wiremock/stubs/user-timer-endpoint.json")
   @KeycloakRealms("/json/keycloak/test-realm.json")
   void create_positive_simpleTrigger() throws Exception {

--- a/src/test/java/org/folio/scheduler/it/SchedulerTimerRepositoryIT.java
+++ b/src/test/java/org/folio/scheduler/it/SchedulerTimerRepositoryIT.java
@@ -64,23 +64,23 @@ class SchedulerTimerRepositoryIT extends BaseIntegrationTest {
 
   @Test
   @Sql(scripts = "classpath:/sql/timer-repo-it.sql", executionPhase = BEFORE_TEST_METHOD)
-  void switchTimersByModuleNameAndType_shouldSetEnabledTrue_forTimersWithEnabledFalseOrNull() {
+  void switchTimersByModuleNameAndEnabledState_shouldSetEnabledTrue_forUserAndSystemTimers() {
     var enabled = true;
 
     try (var ignored = new FolioExecutionContextSetter(folioModuleMetadata, prepareContextHeaders())) {
       var timers = repository.findByModuleNameAndEnabledState(MODULE_NAME, enabled);
       repository.switchTimersByIds(timers.stream().map(TimerDescriptorEntity::getId).toList(), enabled);
 
-      assertThat(timers).hasSize(2);
+      assertThat(timers).hasSize(3);
       assertThat(repository.findAll())
-        .hasSize(3)
+        .hasSize(4)
         .allSatisfy(t -> assertThat(t.getTimerDescriptor().getEnabled()).isTrue());
     }
   }
 
   @Test
   @Sql(scripts = "classpath:/sql/timer-repo-it.sql", executionPhase = BEFORE_TEST_METHOD)
-  void switchTimersByModuleNameAndType_shouldSetEnabledFalse_forTimersWithEnabledTrue() {
+  void switchTimersByModuleNameAndEnabledState_shouldSetEnabledFalse_forUserAndSystemTimers() {
     var enabled = false;
 
     try (var ignored = new FolioExecutionContextSetter(folioModuleMetadata, prepareContextHeaders())) {
@@ -89,7 +89,7 @@ class SchedulerTimerRepositoryIT extends BaseIntegrationTest {
 
       assertThat(timers).hasSize(1);
       assertThat(repository.findAll())
-        .hasSize(3)
+        .hasSize(4)
         .allSatisfy(t -> {
           if (nonNull(t.getTimerDescriptor().getEnabled())) {
             assertThat(t.getTimerDescriptor().getEnabled()).isFalse();

--- a/src/test/java/org/folio/scheduler/service/SchedulerTimerServiceTest.java
+++ b/src/test/java/org/folio/scheduler/service/SchedulerTimerServiceTest.java
@@ -98,8 +98,22 @@ class SchedulerTimerServiceTest {
     var expectedTimerDescriptors = new PageImpl<>(singletonList(entity));
     when(repository.findAll(OffsetRequest.of(0, 100))).thenReturn(expectedTimerDescriptors);
     when(mapper.toDescriptor(entity)).thenReturn(timerDescriptor());
-    var actual = service.getAll(0, 100);
+    var actual = service.getAll(null, 0, 100);
     assertThat(actual).isEqualTo(SearchResult.of(1, singletonList(timerDescriptor())));
+  }
+
+  @Test
+  void getAll_positive_query() {
+    var entity = timerDescriptorEntity();
+    var query = "moduleName==mod-foo";
+    var offsetRequest = OffsetRequest.of(0, 1);
+    var expectedTimerDescriptors = new PageImpl<>(singletonList(entity), offsetRequest, 5);
+    when(repository.findByCql(query, offsetRequest)).thenReturn(expectedTimerDescriptors);
+    when(mapper.toDescriptor(entity)).thenReturn(timerDescriptor());
+
+    var actual = service.getAll(query, 0, 1);
+
+    assertThat(actual).isEqualTo(SearchResult.of(5, singletonList(timerDescriptor())));
   }
 
   @Test

--- a/src/test/resources/sql/timer-repo-it.sql
+++ b/src/test/resources/sql/timer-repo-it.sql
@@ -51,4 +51,22 @@ values
           }
         }
        }'
+    ),
+    ('123e4567-e89b-12d3-a456-426614174003', 'mod-foo-1.0.0', 'mod-foo', 'SYSTEM', '{
+        "id": "123e4567-e89b-12d3-a456-426614174003",
+        "modified": "false",
+        "enabled": "false",
+        "moduleId": "mod-foo-1.0.0",
+        "moduleName": "mod-foo",
+        "type": "system",
+        "routingEntry": {
+          "methods": [
+            "POST"
+          ],
+          "pathPattern": "/testb/timer/4",
+          "schedule": {
+            "cron": "*/4 * * * *"
+          }
+        }
+       }'
     );


### PR DESCRIPTION
### **Purpose**
Add CQL query support to the timer list endpoint: https://folio-org.atlassian.net/browse/MODSCHED-88.
This makes `/scheduler/timers` searchable by supported timer table fields while keeping JSON-only descriptor fields out of the CQL contract.
The change also preserves module entitlement behavior for both USER and SYSTEM timers.

### **Approach**
- Added the optional `query` parameter to the timer list API and passed it through the controller and service.
- Replaced the timer repository base interface with `JpaCqlRepository` and routed non-blank queries through `findByCql`.
- Documented supported CQL fields as `moduleName`, `moduleId`, and `type`, with `enabled` intentionally unsupported.
- Added coverage for single-field and combined CQL queries, unsupported `enabled` filtering, and entitlement switching across USER and SYSTEM timers.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
