### PR TITLE
MODSCHED-76 Add initial delay for system timers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * Enforce system-user execution for SYSTEM timers (MODSCHED-72)
 * Improve structured logging for timer execution (MODSCHED-92)
 * Retry transient timer execution failures with backoff and prevent timers overlapping themselves (MODSCHED-70)
+* Delay first invocation of SYSTEM timers (MODSCHED-76)
 ---
 
 ## Version `v4.0.0` (17.04.2026)

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ docker run \
 | TOKEN_CACHE_REFRESH_PRIOR_EXPIRATION       | 25                     | Specifies the amount of seconds for a cache entry invalidation prior to the token expiration.                                                                         |
 | SCHEDULER_API_ALLOW_SYSTEM_TIMER_MUTATION  | false                  | Allow REST APIs to create, update, and delete SYSTEM timers.                                                                                                          |
 | SCHEDULER_API_ALLOW_USER_ID_UPDATE         | false                  | Allow a USER timer's `userId` to be refreshed to the updating user on update. When `false`, `userId` is set once on creation and preserved across updates.            |
+| SCHEDULER_SYSTEM_TIMER_INITIAL_DELAY       | 0s                     | Initial delay for SYSTEM delay-based timers. The delay is skipped for USER timers, cron timers, and SYSTEM timers whose interval is less than or equal to the configured delay.              |
 
 ### Kafka environment variables
 

--- a/src/main/java/org/folio/scheduler/configuration/properties/SystemTimerConfigurationProperties.java
+++ b/src/main/java/org/folio/scheduler/configuration/properties/SystemTimerConfigurationProperties.java
@@ -1,0 +1,17 @@
+package org.folio.scheduler.configuration.properties;
+
+import java.time.Duration;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+@ConfigurationProperties("application.timer.system")
+public class SystemTimerConfigurationProperties {
+
+  /**
+   * Initial delay for SYSTEM simple timers.
+   */
+  private Duration initialDelay = Duration.ZERO;
+}

--- a/src/main/java/org/folio/scheduler/service/JobSchedulingService.java
+++ b/src/main/java/org/folio/scheduler/service/JobSchedulingService.java
@@ -206,7 +206,10 @@ public class JobSchedulingService {
 
     var initialDelay = getSystemTimerInitialDelay(timerDescriptor, repeatInterval);
     if (!initialDelay.isZero()) {
-      triggerBuilder.startAt(Date.from(Instant.now().plus(initialDelay)));
+      var startAt = Instant.now().plus(initialDelay);
+      log.info("Applying SYSTEM timer initial delay [timerId: {}, initialDelay: {}, startAt: {}]",
+        timerDescriptor.getId(), initialDelay, startAt);
+      triggerBuilder.startAt(Date.from(startAt));
     }
 
     return triggerBuilder.build();

--- a/src/main/java/org/folio/scheduler/service/JobSchedulingService.java
+++ b/src/main/java/org/folio/scheduler/service/JobSchedulingService.java
@@ -24,10 +24,14 @@ import static org.quartz.SimpleScheduleBuilder.simpleSchedule;
 import static org.quartz.TriggerBuilder.newTrigger;
 import static org.quartz.TriggerKey.triggerKey;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
 import java.util.Map;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.folio.scheduler.configuration.properties.SystemTimerConfigurationProperties;
 import org.folio.scheduler.domain.dto.TimerDescriptor;
 import org.folio.scheduler.domain.dto.TimerType;
 import org.folio.scheduler.domain.dto.TimerUnit;
@@ -51,6 +55,7 @@ public class JobSchedulingService {
 
   private final Scheduler scheduler;
   private final FolioExecutionContext folioExecutionContext;
+  private final SystemTimerConfigurationProperties systemTimerConfigurationProperties;
 
   /**
    * Contains multiplication value to convert request delay to milliseconds.
@@ -94,7 +99,8 @@ public class JobSchedulingService {
    * This method only changes the trigger for existing task.
    * </p>
    *
-   * @param timerDescriptor - recurring job descriptor
+   * @param oldTimerDescriptor - previous recurring job descriptor
+   * @param timerDescriptor    - new recurring job descriptor
    */
   @Transactional
   public void reschedule(TimerDescriptor oldTimerDescriptor, TimerDescriptor timerDescriptor) {
@@ -192,11 +198,18 @@ public class JobSchedulingService {
     var group = jobGroup(timerDescriptor);
     var repeatInterval = timerUnitFactorMap.get(re.getUnit()) * Long.parseLong(re.getDelay());
     Validate.isTrue(repeatInterval >= 1000L, () -> "Repeat interval must be greater than 1 second.");
-    return newTrigger()
+
+    var triggerBuilder = newTrigger()
       .withIdentity(triggerKey(timerId, group))
       .withSchedule(simpleSchedule().repeatForever().withIntervalInMilliseconds(repeatInterval))
-      .forJob(jobKey(timerId, group))
-      .build();
+      .forJob(jobKey(timerId, group));
+
+    var initialDelay = getSystemTimerInitialDelay(timerDescriptor, repeatInterval);
+    if (!initialDelay.isZero()) {
+      triggerBuilder.startAt(Date.from(Instant.now().plus(initialDelay)));
+    }
+
+    return triggerBuilder.build();
   }
 
   private CronTrigger getCronTrigger(TimerDescriptor timerDescriptor) {
@@ -211,6 +224,31 @@ public class JobSchedulingService {
       .withSchedule(cronSchedule(cronExpression).inTimeZone(getTimeZone(timeZone)))
       .forJob(jobKey(timerId, group))
       .build();
+  }
+
+  private Duration getSystemTimerInitialDelay(TimerDescriptor timerDescriptor, long repeatInterval) {
+    if (timerDescriptor.getType() != TimerType.SYSTEM) {
+      return Duration.ZERO;
+    }
+
+    var configuredDelay = systemTimerConfigurationProperties.getInitialDelay();
+    if (configuredDelay == null || configuredDelay.isZero() || configuredDelay.isNegative()) {
+      return Duration.ZERO;
+    }
+
+    var configuredDelayMillis = configuredDelay.toMillis();
+    if (configuredDelayMillis <= 0L) {
+      return Duration.ZERO;
+    }
+
+    if (configuredDelayMillis >= repeatInterval) {
+      log.info("Skipping SYSTEM timer initial delay because it is greater than or equal to the repeat interval. "
+          + "[timerId: {}, initialDelay: {}, repeatIntervalMs: {}]",
+        timerDescriptor.getId(), configuredDelay, repeatInterval);
+      return Duration.ZERO;
+    }
+
+    return configuredDelay;
   }
 
   private static boolean isTriggerDisabled(TimerDescriptor desc) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -93,6 +93,8 @@ application:
     api:
       allow-system-timer-mutation: ${SCHEDULER_API_ALLOW_SYSTEM_TIMER_MUTATION:false}
       allow-user-id-update: ${SCHEDULER_API_ALLOW_USER_ID_UPDATE:false}
+    system:
+      initial-delay: ${SCHEDULER_SYSTEM_TIMER_INITIAL_DELAY:0s}
   kafka:
     consumer:
       listener:

--- a/src/test/java/org/folio/scheduler/service/JobSchedulingServiceTest.java
+++ b/src/test/java/org/folio/scheduler/service/JobSchedulingServiceTest.java
@@ -28,8 +28,11 @@ import static org.quartz.SimpleScheduleBuilder.simpleSchedule;
 import static org.quartz.TriggerBuilder.newTrigger;
 import static org.quartz.TriggerKey.triggerKey;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Date;
 import java.util.stream.Stream;
+import org.folio.scheduler.configuration.properties.SystemTimerConfigurationProperties;
 import org.folio.scheduler.domain.dto.RoutingEntry;
 import org.folio.scheduler.domain.dto.RoutingEntrySchedule;
 import org.folio.scheduler.domain.dto.TimerType;
@@ -67,6 +70,7 @@ class JobSchedulingServiceTest {
   @InjectMocks private JobSchedulingService service;
   @Mock private Scheduler scheduler;
   @Mock private FolioExecutionContext folioExecutionContext;
+  @Mock private SystemTimerConfigurationProperties systemTimerConfigurationProperties;
 
   @Captor private ArgumentCaptor<Trigger> triggerArgumentCaptor;
   @Captor private ArgumentCaptor<JobDetail> jobDetailArgumentCaptor;
@@ -103,6 +107,71 @@ class JobSchedulingServiceTest {
     assertThat(actualTrigger).isEqualTo(simpleTrigger(expectedRepeatInterval));
     assertThat(actualTrigger.getRepeatInterval()).isEqualTo(expectedRepeatInterval);
     assertThat(actualTrigger.getRepeatCount()).isEqualTo(-1);
+  }
+
+  @Test
+  void schedule_positive_systemSimpleTimerAppliesInitialDelay() throws SchedulerException {
+    when(folioExecutionContext.getTenantId()).thenReturn(TENANT_ID);
+    when(systemTimerConfigurationProperties.getInitialDelay()).thenReturn(Duration.ofSeconds(5));
+    when(scheduler.scheduleJob(any(JobDetail.class), triggerArgumentCaptor.capture())).thenReturn(new Date());
+    var routingEntry = new RoutingEntry().delay("20").unit(SECOND);
+    var timerDescriptor = timerDescriptor().type(TimerType.SYSTEM).routingEntry(routingEntry);
+
+    var beforeSchedule = Instant.now();
+    var scheduled = service.schedule(timerDescriptor);
+    var afterSchedule = Instant.now();
+
+    assertThat(scheduled).isTrue();
+    var actualTrigger = (SimpleTrigger) triggerArgumentCaptor.getValue();
+    assertThat(actualTrigger.getRepeatInterval()).isEqualTo(20_000L);
+    assertThat(actualTrigger.getRepeatCount()).isEqualTo(-1);
+    assertThat(actualTrigger.getStartTime())
+      .isBetween(Date.from(beforeSchedule.plusSeconds(5)), Date.from(afterSchedule.plusSeconds(5).plusMillis(250)));
+  }
+
+  @Test
+  void schedule_positive_userSimpleTimerDoesNotApplySystemInitialDelay() throws SchedulerException {
+    when(folioExecutionContext.getTenantId()).thenReturn(TENANT_ID);
+    when(scheduler.scheduleJob(any(JobDetail.class), triggerArgumentCaptor.capture())).thenReturn(new Date());
+    var routingEntry = new RoutingEntry().delay("20").unit(SECOND);
+    var timerDescriptor = timerDescriptor().type(TimerType.USER).userId(USER_ID_UUID).routingEntry(routingEntry);
+
+    var beforeSchedule = Instant.now();
+    service.schedule(timerDescriptor);
+
+    var actualTrigger = (SimpleTrigger) triggerArgumentCaptor.getValue();
+    assertThat(actualTrigger.getStartTime()).isBefore(Date.from(beforeSchedule.plusSeconds(5)));
+    verifyNoInteractions(systemTimerConfigurationProperties);
+  }
+
+  @Test
+  void schedule_positive_systemSimpleTimerSkipsInitialDelayWhenDelayMatchesInterval()
+    throws SchedulerException {
+    when(folioExecutionContext.getTenantId()).thenReturn(TENANT_ID);
+    when(systemTimerConfigurationProperties.getInitialDelay()).thenReturn(Duration.ofSeconds(20));
+    when(scheduler.scheduleJob(any(JobDetail.class), triggerArgumentCaptor.capture())).thenReturn(new Date());
+    var routingEntry = new RoutingEntry().delay("20").unit(SECOND);
+    var timerDescriptor = timerDescriptor().type(TimerType.SYSTEM).routingEntry(routingEntry);
+
+    var beforeSchedule = Instant.now();
+    service.schedule(timerDescriptor);
+
+    var actualTrigger = (SimpleTrigger) triggerArgumentCaptor.getValue();
+    assertThat(actualTrigger.getStartTime()).isBefore(Date.from(beforeSchedule.plusSeconds(20)));
+  }
+
+  @Test
+  void schedule_positive_systemCronTimerDoesNotApplySystemInitialDelay() throws SchedulerException {
+    var cronSchedule = new RoutingEntrySchedule().cron("*/5 * * * * ?").zone("UTC");
+    when(folioExecutionContext.getTenantId()).thenReturn(TENANT_ID);
+    when(scheduler.scheduleJob(any(JobDetail.class), triggerArgumentCaptor.capture())).thenReturn(new Date());
+    var routingEntry = new RoutingEntry().schedule(cronSchedule);
+    var timerDescriptor = timerDescriptor().type(TimerType.SYSTEM).routingEntry(routingEntry);
+
+    service.schedule(timerDescriptor);
+
+    assertThat(triggerArgumentCaptor.getValue()).isEqualTo(cronTrigger("*/5 * * * * ?", "UTC"));
+    verifyNoInteractions(systemTimerConfigurationProperties);
   }
 
   @Test


### PR DESCRIPTION
### **Purpose**
Changes for [MODSCHED-76](https://folio-org.atlassian.net/browse/MODSCHED-76)

### **Approach**
Added configurable `SCHEDULER_SYSTEM_TIMER_INITIAL_DELAY` for SYSTEM simple timers, applied only when the delay is positive and less than the timer’s repeat interval.

Cron and USER timers remain unchanged

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [x] **New Properties / Environment Variables** — Updated README.md if new configs were added.
