### PR TITLE
MODSCHED-70: retry timer execution failures and prevent overlapping executions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Add CQL filtering support for scheduler timers (MODSCHED-88)
 * Enforce system-user execution for SYSTEM timers (MODSCHED-72)
 * Improve structured logging for timer execution (MODSCHED-92)
+* Retry transient timer execution failures with backoff and prevent timers overlapping themselves (MODSCHED-70)
 ---
 
 ## Version `v4.0.0` (17.04.2026)

--- a/README.md
+++ b/README.md
@@ -181,10 +181,34 @@ Two independent strategies control the behaviour:
 | USER_IMPERSONATION_RETRY_MULTIPLIER | 1.5           | Retry attempts delay multiplier to obtain a user impersonation token                                                                    |
 | SCHEDULED_TIMER_EVENT_RETRY_DELAY   | 1s            | Retry delay between attempts to process event from `scheduled-job` Kafka topic                                                          |
 | SCHEDULED_TIMER_EVENT_ATTEMPTS      | 2147483647    | Number of attempts to process event from `scheduled-job` Kafka topic (default value is Integer.MAX_VALUE ~= infinite amount of retries) |
+| TIMER_EXECUTION_RETRY_DELAY         | 3s            | Initial backoff before the first retry of a timer HTTP call                                                                             |
+| TIMER_EXECUTION_RETRY_MAX_DELAY     | 10s           | Ceiling for the backoff between retries                                                                                                 |
+| TIMER_EXECUTION_RETRY_ATTEMPTS      | 4             | Number of attempts for a timer HTTP call, including the initial one; `1` disables retries                                               |
+| TIMER_EXECUTION_RETRY_MULTIPLIER    | 2             | Exponential multiplier applied to the backoff between retries                                                                           |
 
 Timer execution uses a Keycloak user impersonation token as `X-Okapi-Token`. If token exchange returns a blank,
 missing, or literal `null` token, the response is not cached and the impersonation request is retried according to
 the `USER_IMPERSONATION_*` settings. If a valid token still cannot be obtained, the timer request is not sent.
+
+#### Timer-execution retry behaviour
+
+When a scheduled timer's HTTP call to a module fails with a transient error, mod-scheduler retries it with
+exponential backoff before giving up. The set of failures treated as transient is an **allowlist** — everything
+not listed is treated as permanent and not retried:
+
+- any `5xx` with sidecar error code `authorization_error`;
+- connection refused, connect timeout, or connection-pool timeout before the request is sent.
+
+Notably **not** retried: generic `5xx`, any `4xx` including `400`, `401`, `403`, `404`, `408` and `429`, read
+timeouts, other I/O failures, DNS failures, and TLS failures. A read timeout is excluded because the target may
+still be processing the first request.
+
+The allowlist deliberately excludes failures that may occur after the target module started processing the request.
+Each retry emits a structured `timer.execution.retry` log with its retry number and reason; response bodies and
+exception messages are not logged.
+
+A single timer never overlaps itself: `@DisallowConcurrentExecution` holds the next fire until the running
+execution completes, per timer and cluster-wide. This applies to **every** timer, not only ones that retry.
 
 ### Secure storage environment variables
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,7 @@
+# Module Features
+
+This module provides the following features:
+
+| Feature | Description |
+|---------|-------------|
+| [Scheduled Timer Delivery](features/scheduled-timer-delivery.md) | Delivers scheduled timer requests with safe transient-failure retries and per-timer execution serialization. |

--- a/docs/features/scheduled-timer-delivery.md
+++ b/docs/features/scheduled-timer-delivery.md
@@ -1,0 +1,47 @@
+---
+feature_id: scheduled-timer-delivery
+title: Scheduled Timer Delivery
+updated: 2026-07-27
+---
+
+# Scheduled Timer Delivery
+
+## What it does
+Configured timers invoke the selected module HTTP endpoint when their Quartz schedule fires. Delivery retries a limited set of transient failures with exponential backoff, and prevents concurrent executions of the same timer across the Quartz cluster.
+
+## Why it exists
+Scheduled work should recover from safe, short-lived availability failures without duplicating work that may already be in progress. Serializing each timer's executions protects downstream modules from overlapping requests for the same timer.
+
+## Entry point(s)
+| Type | Schedule | Description |
+|------|----------|-------------|
+| Scheduled Job | Timer delay or cron schedule | Invokes the timer routing entry's configured HTTP method and path. |
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | /scheduler/timers | Creates a timer that is scheduled for delivery. |
+| PUT | /scheduler/timers/{id} | Updates a timer's delivery schedule or routing entry. |
+
+## Business rules and constraints
+- A delivery uses the timer routing entry's GET, POST, PUT, or DELETE method and its configured path.
+- Only a 5xx response containing error code `authorization_error`, connection refused, connect timeout, and connection-pool timeout are retried.
+- Generic 5xx responses, all 4xx responses, read timeouts, DNS failures, TLS failures, and other I/O failures are not retried.
+- Retry attempts include the initial request; the default maximum is four attempts.
+- Retries reuse the same prepared timer request context; the timer is not re-read and the user is not re-impersonated between attempts.
+- Quartz blocks a subsequent fire of the same timer until its active execution completes, including when the timer runs on another cluster instance.
+
+## Error behavior
+- A retryable failure is attempted until the configured attempt limit is reached; the final failure is logged as `timer.execution.failure`.
+- A non-retryable HTTP or transport failure is logged once as `timer.execution.failure` without another delivery attempt.
+- Each retry emits a `timer.execution.retry` structured log event with its retry number and classified reason.
+
+## Configuration
+| Variable | Purpose |
+|----------|---------|
+| `TIMER_EXECUTION_RETRY_DELAY` | Initial delay before retrying a timer HTTP call; default `3s`. |
+| `TIMER_EXECUTION_RETRY_MAX_DELAY` | Maximum delay between timer HTTP-call retries; default `10s`. |
+| `TIMER_EXECUTION_RETRY_ATTEMPTS` | Maximum delivery attempts, including the initial request; default `4`. |
+| `TIMER_EXECUTION_RETRY_MULTIPLIER` | Exponential backoff multiplier between delivery attempts; default `2`. |
+
+## Dependencies and interactions
+Timer delivery sends the configured HTTP request to the sidecar. The sidecar routes it to the selected module using module-to-module calls.

--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,12 @@
       <version>${spring-retry.version}</version>
     </dependency>
 
+    <!-- Explicit compile-scope dependency: OkapiClient disables HttpClient's transport-level retries directly. -->
+    <dependency>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>io.hypersistence</groupId>
       <artifactId>hypersistence-utils-hibernate-73</artifactId>

--- a/src/main/java/org/folio/scheduler/configuration/HttpClientConfiguration.java
+++ b/src/main/java/org/folio/scheduler/configuration/HttpClientConfiguration.java
@@ -1,15 +1,37 @@
 package org.folio.scheduler.configuration;
 
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.folio.scheduler.integration.OkapiClient;
+import org.springframework.boot.http.client.ClientHttpRequestFactoryBuilder;
+import org.springframework.boot.http.client.HttpClientSettings;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.support.NotFoundRestClientAdapterDecorator;
+import org.springframework.web.client.support.RestClientAdapter;
 import org.springframework.web.service.invoker.HttpServiceProxyFactory;
 
 @Configuration
 public class HttpClientConfiguration {
 
+  /**
+   * Builds {@link OkapiClient} with Apache HttpClient's transport-level retries disabled, so that the timer retry
+   * policy is the only one repeating a request. The shared folio builder is cloned rather than mutated to keep other
+   * folio clients unaffected.
+   */
   @Bean
-  public OkapiClient okapiClient(HttpServiceProxyFactory factory) {
-    return factory.createClient(OkapiClient.class);
+  public OkapiClient okapiClient(RestClient.Builder folioRestClientBuilder) {
+    var requestFactory = ClientHttpRequestFactoryBuilder.httpComponents()
+      .withHttpClientCustomizer(HttpClientBuilder::disableAutomaticRetries)
+      .build(HttpClientSettings.defaults());
+    var restClient = folioRestClientBuilder.clone()
+      .requestFactory(requestFactory)
+      .build();
+
+    return HttpServiceProxyFactory
+      .builderFor(RestClientAdapter.create(restClient))
+      .exchangeAdapterDecorator(NotFoundRestClientAdapterDecorator::new)
+      .build()
+      .createClient(OkapiClient.class);
   }
 }

--- a/src/main/java/org/folio/scheduler/configuration/TimerExecutionRetryConfiguration.java
+++ b/src/main/java/org/folio/scheduler/configuration/TimerExecutionRetryConfiguration.java
@@ -23,7 +23,7 @@ public class TimerExecutionRetryConfiguration {
    */
   @Bean(name = "timerExecutionRetryTemplate")
   public RetryTemplate timerExecutionRetryTemplate(RetryConfigurationProperties properties,
-    TimerExecutionRetryClassifier classifier) {
+                                                   TimerExecutionRetryClassifier classifier) {
     var config = properties.getConfig().get("timer-execution");
     return RetryTemplate.builder()
       .maxAttempts((int) config.getRetryAttempts())

--- a/src/main/java/org/folio/scheduler/configuration/TimerExecutionRetryConfiguration.java
+++ b/src/main/java/org/folio/scheduler/configuration/TimerExecutionRetryConfiguration.java
@@ -1,0 +1,34 @@
+package org.folio.scheduler.configuration;
+
+import org.folio.scheduler.configuration.properties.RetryConfigurationProperties;
+import org.folio.scheduler.service.jobs.TimerExecutionRetryClassifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.support.RetryTemplate;
+
+/**
+ * Retry policy for timer HTTP calls.
+ *
+ * <p>Kept apart from {@link RetryConfiguration}, which unrelated test slices import for {@code @EnableRetry}.</p>
+ */
+@Configuration
+public class TimerExecutionRetryConfiguration {
+
+  /**
+   * Builds a template whose {@code retryAttempts} include the initial call.
+   *
+   * @param properties - {@link RetryConfigurationProperties} component
+   * @param classifier - decides which timer execution failures are retryable
+   * @return {@link RetryTemplate} for {@link org.folio.scheduler.service.jobs.OkapiHttpRequestExecutor}
+   */
+  @Bean(name = "timerExecutionRetryTemplate")
+  public RetryTemplate timerExecutionRetryTemplate(RetryConfigurationProperties properties,
+    TimerExecutionRetryClassifier classifier) {
+    var config = properties.getConfig().get("timer-execution");
+    return RetryTemplate.builder()
+      .maxAttempts((int) config.getRetryAttempts())
+      .retryOn(classifier::isRetryable)
+      .exponentialBackoff(config.getRetryDelay(), config.getRetryMultiplier(), config.getMaxDelay())
+      .build();
+  }
+}

--- a/src/main/java/org/folio/scheduler/service/jobs/OkapiHttpRequestExecutor.java
+++ b/src/main/java/org/folio/scheduler/service/jobs/OkapiHttpRequestExecutor.java
@@ -38,15 +38,19 @@ import org.folio.scheduler.service.SchedulerTimerService;
 import org.folio.scheduler.service.UserImpersonationService;
 import org.folio.spring.FolioModuleMetadata;
 import org.folio.spring.scope.FolioExecutionContextSetter;
+import org.quartz.DisallowConcurrentExecution;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.springframework.http.HttpMethod;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestClientException;
 
 @Log4j2
 @Component
+@DisallowConcurrentExecution
 public class OkapiHttpRequestExecutor implements Job {
 
   private final FolioModuleMetadata folioModuleMetadata;
@@ -55,23 +59,30 @@ public class OkapiHttpRequestExecutor implements Job {
   private final Map<HttpMethod, BiConsumer<URI, String>> okapiCallMap;
   private final UserImpersonationService userImpersonationService;
   private final SystemUserService systemUserService;
+  private final RetryTemplate retryTemplate;
+  private final TimerExecutionRetryClassifier retryClassifier;
 
   /**
    * Injects required spring components into {@link OkapiHttpRequestExecutor} bean.
    *
-   * @param okapiClient - {@link OkapiClient} feign client
+   * @param okapiClient - {@link OkapiClient} http client
    * @param folioModuleMetadata - {@link FolioModuleMetadata} component
    * @param schedulerTimerService - {@link SchedulerTimerService} service
    * @param okapiConfigurationProperties - {@link OkapiConfigurationProperties} component
+   * @param retryTemplate - retry policy applied to the module http call
+   * @param retryClassifier - decides which module http failures are retryable
    */
   public OkapiHttpRequestExecutor(OkapiClient okapiClient, FolioModuleMetadata folioModuleMetadata,
     SchedulerTimerService schedulerTimerService, OkapiConfigurationProperties okapiConfigurationProperties,
-    UserImpersonationService userImpersonationService, SystemUserService systemUserService) {
+    UserImpersonationService userImpersonationService, SystemUserService systemUserService,
+    RetryTemplate retryTemplate, TimerExecutionRetryClassifier retryClassifier) {
     this.folioModuleMetadata = folioModuleMetadata;
     this.schedulerTimerService = schedulerTimerService;
     this.okapiConfigurationProperties = okapiConfigurationProperties;
     this.userImpersonationService = userImpersonationService;
     this.systemUserService = systemUserService;
+    this.retryTemplate = retryTemplate;
+    this.retryClassifier = retryClassifier;
 
     this.okapiCallMap = Map.ofEntries(
       entry(GET, okapiClient::doGet),
@@ -106,14 +117,39 @@ public class OkapiHttpRequestExecutor implements Job {
       return;
     }
 
+    invokeModule(okapiCallExecutor, staticPath, moduleHint, logContext);
+  }
+
+  private void invokeModule(BiConsumer<URI, String> okapiCallExecutor, String staticPath, String moduleHint,
+    TimerExecutionLogContext logContext) {
     logStart(logContext);
     var startNanos = System.nanoTime();
+    var uri = fromUriString("http:/" + staticPath).build().toUri();
+
     try {
-      okapiCallExecutor.accept(fromUriString("http:/" + staticPath).build().toUri(), moduleHint);
+      executeWithRetry(okapiCallExecutor, uri, moduleHint, logContext);
       logSuccess(logContext, startNanos);
     } catch (RestClientException e) {
       logFailure(logContext, startNanos, e);
     }
+  }
+
+  /**
+   * Runs the module call under the retry policy.
+   *
+   * <p>Only the call itself is retried: header preparation and the timer lookup stay outside the loop, so a retry
+   * neither re-impersonates the user nor re-reads the timer. {@code X-Okapi-Request-Id} therefore stays stable
+   * across attempts, and per-retry correlation is carried by the {@code retryNumber} log field instead.</p>
+   */
+  private void executeWithRetry(BiConsumer<URI, String> okapiCallExecutor, URI uri, String moduleHint,
+    TimerExecutionLogContext logContext) {
+    retryTemplate.execute(retryContext -> {
+      if (retryContext.getRetryCount() > 0) {
+        logRetryAttempt(logContext, retryContext);
+      }
+      okapiCallExecutor.accept(uri, moduleHint);
+      return null;
+    });
   }
 
   private void logUnsupportedMethod(TimerExecutionLogContext logContext) {
@@ -132,6 +168,19 @@ public class OkapiHttpRequestExecutor implements Job {
       .with("durationMs", durationMs(startNanos)));
   }
 
+  /**
+   * Logged when each retry starts, naming the classified cause of the previous failure.
+   */
+  private void logRetryAttempt(TimerExecutionLogContext logContext, RetryContext retryContext) {
+    log.warn(timerExecutionMessage("timer.execution.retry", logContext)
+      .with("outcome", "RETRY")
+      .with("retryNumber", retryContext.getRetryCount())
+      .with("reason", retryClassifier.classify(retryContext.getLastThrowable()).name()));
+  }
+
+  /**
+   * Logged once per execution, after the retry sequence ends.
+   */
   private void logFailure(TimerExecutionLogContext logContext, long startNanos, RestClientException exception) {
     var message = timerExecutionMessage("timer.execution.failure", logContext)
       .with("outcome", "FAILURE")

--- a/src/main/java/org/folio/scheduler/service/jobs/TimerExecutionRetryClassifier.java
+++ b/src/main/java/org/folio/scheduler/service/jobs/TimerExecutionRetryClassifier.java
@@ -1,0 +1,111 @@
+package org.folio.scheduler.service.jobs;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.hc.client5.http.ConnectTimeoutException;
+import org.apache.hc.core5.http.ConnectionRequestTimeoutException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestClientException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+
+import java.net.ConnectException;
+
+import static org.folio.scheduler.service.jobs.TimerExecutionRetryClassifier.RetryReason.*;
+
+/**
+ * Decides whether a failed timer HTTP call may be retried.
+ *
+ * <p>This is an <b>allowlist</b>: only the failures enumerated here are retried, anything else is treated as
+ * permanent. Timer handlers are predominantly {@code POST} and some of them charge fees or send patron notices, so an
+ * unrecognised failure must not be repeated.</p>
+ */
+@Component
+@RequiredArgsConstructor
+public class TimerExecutionRetryClassifier {
+
+  private static final String AUTHORIZATION_ERROR = "authorization_error";
+
+  private final ObjectMapper objectMapper;
+
+  /**
+   * Tells whether the given timer execution failure is transient and worth retrying.
+   *
+   * @param throwable - failure thrown by the module HTTP call
+   * @return {@code true} if the call may be retried, {@code false} otherwise
+   */
+  public boolean isRetryable(Throwable throwable) {
+    return classify(throwable) != null;
+  }
+
+  /**
+   * Classifies a failure to name the retry cause in logs.
+   *
+   * @param throwable failed timer call
+   * @return matched retry reason, or {@code null} when the failure is not retryable
+   */
+  public RetryReason classify(Throwable throwable) {
+    if (throwable == null) {
+      return null;
+    }
+
+    if (throwable instanceof HttpStatusCodeException statusException) {
+      return classifyStatusFailure(statusException);
+    }
+
+    return classifyTransportFailure(unwrap(throwable));
+  }
+
+  private RetryReason classifyStatusFailure(HttpStatusCodeException exception) {
+    if (exception.getStatusCode().is5xxServerError() && hasErrorCode(exception, AUTHORIZATION_ERROR)) {
+      return AUTHORIZATION_SERVICE_UNAVAILABLE;
+    }
+    return null;
+  }
+
+  private static RetryReason classifyTransportFailure(Throwable cause) {
+    if (cause instanceof ConnectTimeoutException) {
+      return CONNECT_TIMEOUT;
+    }
+    if (cause instanceof ConnectionRequestTimeoutException) {
+      return CONNECTION_POOL_TIMEOUT;
+    }
+    if (cause instanceof ConnectException) {
+      return CONNECTION_REFUSED;
+    }
+    return null;
+  }
+
+  private boolean hasErrorCode(HttpStatusCodeException exception, String expectedCode) {
+    try {
+      var errors = objectMapper.readTree(exception.getResponseBodyAsByteArray()).path("errors");
+      if (errors.isArray()) {
+        for (var error : errors) {
+          if (expectedCode.equals(error.path("code").asString(null))) {
+            return true;
+          }
+        }
+      }
+    } catch (JacksonException ignored) {
+      // Malformed or absent error details are intentionally non-retryable.
+    }
+    return false;
+  }
+
+  /**
+   * Unwraps the transport exception that Spring wraps into a {@link RestClientException}.
+   */
+  private static Throwable unwrap(Throwable throwable) {
+    if (throwable instanceof RestClientException && throwable.getCause() != null) {
+      return throwable.getCause();
+    }
+    return throwable;
+  }
+
+  public enum RetryReason {
+    AUTHORIZATION_SERVICE_UNAVAILABLE,
+    CONNECTION_REFUSED,
+    CONNECT_TIMEOUT,
+    CONNECTION_POOL_TIMEOUT
+  }
+}

--- a/src/main/java/org/folio/scheduler/service/jobs/TimerExecutionRetryClassifier.java
+++ b/src/main/java/org/folio/scheduler/service/jobs/TimerExecutionRetryClassifier.java
@@ -1,5 +1,11 @@
 package org.folio.scheduler.service.jobs;
 
+import static org.folio.scheduler.service.jobs.TimerExecutionRetryClassifier.RetryReason.AUTHORIZATION_SERVICE_UNAVAILABLE;
+import static org.folio.scheduler.service.jobs.TimerExecutionRetryClassifier.RetryReason.CONNECTION_POOL_TIMEOUT;
+import static org.folio.scheduler.service.jobs.TimerExecutionRetryClassifier.RetryReason.CONNECTION_REFUSED;
+import static org.folio.scheduler.service.jobs.TimerExecutionRetryClassifier.RetryReason.CONNECT_TIMEOUT;
+
+import java.net.ConnectException;
 import lombok.RequiredArgsConstructor;
 import org.apache.hc.client5.http.ConnectTimeoutException;
 import org.apache.hc.core5.http.ConnectionRequestTimeoutException;
@@ -8,10 +14,6 @@ import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestClientException;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
-
-import java.net.ConnectException;
-
-import static org.folio.scheduler.service.jobs.TimerExecutionRetryClassifier.RetryReason.*;
 
 /**
  * Decides whether a failed timer HTTP call may be retried.

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -128,6 +128,11 @@ application:
       entitlement-event:
         retry-delay: ${ENTITLEMENT_EVENT_RETRY_DELAY:1s}
         retry-attempts: ${ENTITLEMENT_EVENT_ATTEMPTS:2147483647}
+      timer-execution:
+        retry-delay: ${TIMER_EXECUTION_RETRY_DELAY:3s}
+        max-delay: ${TIMER_EXECUTION_RETRY_MAX_DELAY:10s}
+        retry-attempts: ${TIMER_EXECUTION_RETRY_ATTEMPTS:4}
+        retry-multiplier: ${TIMER_EXECUTION_RETRY_MULTIPLIER:2}
   token-cache:
     capacity:
       initial: ${TOKEN_CACHE_INITIAL_CAPACITY:10}

--- a/src/test/java/org/folio/scheduler/it/TimerDisallowConcurrentExecutionIT.java
+++ b/src/test/java/org/folio/scheduler/it/TimerDisallowConcurrentExecutionIT.java
@@ -1,0 +1,97 @@
+package org.folio.scheduler.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS;
+import static org.awaitility.Durations.TEN_SECONDS;
+import static org.folio.scheduler.domain.dto.TimerUnit.SECOND;
+import static org.folio.scheduler.support.TestConstants.MODULE_ID;
+import static org.folio.scheduler.support.TestConstants.MODULE_NAME;
+import static org.folio.scheduler.support.TestConstants.TENANT_ID;
+import static org.hamcrest.Matchers.is;
+import static org.quartz.JobKey.jobKey;
+import static org.quartz.TriggerKey.triggerKey;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import java.util.List;
+import java.util.UUID;
+import org.folio.scheduler.domain.dto.RoutingEntry;
+import org.folio.scheduler.domain.dto.TimerDescriptor;
+import org.folio.scheduler.support.base.BaseIntegrationTest;
+import org.folio.test.extensions.EnableKeycloakTlsMode;
+import org.folio.test.extensions.KeycloakRealms;
+import org.folio.test.extensions.WireMockStub;
+import org.folio.test.types.IntegrationTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger.TriggerState;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+
+/**
+ * Verifies that {@code @DisallowConcurrentExecution} keeps a single timer from overlapping itself (WI-5).
+ *
+ * <p>The timer fires once per second but the endpoint takes three seconds to respond, so without the annotation the
+ * next fire would start on a free Quartz worker while the previous one is still running. With it, the trigger for
+ * the next fire is held in {@link TriggerState#BLOCKED} until the running execution completes - which is what this
+ * test asserts directly, rather than relying on a timing-sensitive call count.</p>
+ */
+@EnableKeycloakTlsMode
+@IntegrationTest
+@Sql(scripts = "classpath:/sql/truncate-tables.sql", executionPhase = AFTER_TEST_METHOD)
+class TimerDisallowConcurrentExecutionIT extends BaseIntegrationTest {
+
+  private static final String JOB_GROUP = TENANT_ID + "#" + MODULE_NAME;
+
+  @Autowired private Scheduler scheduler;
+
+  @BeforeAll
+  static void beforeAll() {
+    setUpTenant();
+  }
+
+  @AfterAll
+  static void afterAll() {
+    removeTenant();
+  }
+
+  @AfterEach
+  void tearDown() throws SchedulerException {
+    scheduler.clear();
+  }
+
+  @Test
+  @WireMockStub("/wiremock/stubs/slow-timer-endpoint.json")
+  @KeycloakRealms("/json/keycloak/test-realm.json")
+  void execute_positive_blocksOverlappingFireUntilRunningJobCompletes() throws Exception {
+    var timerId = UUID.randomUUID();
+    var timerDescriptor = new TimerDescriptor()
+      .id(timerId)
+      .enabled(true)
+      .moduleId(MODULE_ID)
+      .routingEntry(new RoutingEntry()
+        .methods(List.of("POST"))
+        .pathPattern("/test/slow-timer")
+        .delay("1")
+        .unit(SECOND));
+
+    doPost("/scheduler/timers", timerDescriptor).andExpect(jsonPath("$.enabled", is(true)));
+
+    // while the first (3s) execution is running, the next 1s fire is held rather than started concurrently
+    await().atMost(TEN_SECONDS).pollInterval(ONE_HUNDRED_MILLISECONDS)
+      .untilAsserted(() -> assertThat(scheduler.getTriggerState(triggerKey(timerId.toString(), JOB_GROUP)))
+        .isEqualTo(TriggerState.BLOCKED));
+
+    var triggerKey = triggerKey(timerId.toString(), JOB_GROUP);
+    var jobKey = jobKey(timerId.toString(), JOB_GROUP);
+    scheduler.pauseTrigger(triggerKey);
+    await().atMost(TEN_SECONDS).pollInterval(ONE_HUNDRED_MILLISECONDS)
+      .untilAsserted(() -> assertThat(scheduler.getCurrentlyExecutingJobs())
+        .noneMatch(context -> context.getJobDetail().getKey().equals(jobKey)));
+  }
+}

--- a/src/test/java/org/folio/scheduler/it/TimerExecutionRetryIT.java
+++ b/src/test/java/org/folio/scheduler/it/TimerExecutionRetryIT.java
@@ -1,0 +1,140 @@
+package org.folio.scheduler.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS;
+import static org.awaitility.Durations.TEN_SECONDS;
+import static org.folio.scheduler.domain.dto.TimerUnit.MINUTE;
+import static org.folio.scheduler.support.TestConstants.MODULE_ID;
+import static org.folio.scheduler.support.TestConstants.MODULE_NAME;
+import static org.folio.scheduler.support.TestConstants.TENANT_ID;
+import static org.hamcrest.Matchers.is;
+import static org.quartz.JobKey.jobKey;
+import static org.quartz.TriggerKey.triggerKey;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import org.folio.scheduler.domain.dto.RoutingEntry;
+import org.folio.scheduler.domain.dto.TimerDescriptor;
+import org.folio.scheduler.support.base.BaseIntegrationTest;
+import org.folio.test.extensions.EnableKeycloakTlsMode;
+import org.folio.test.extensions.KeycloakRealms;
+import org.folio.test.extensions.WireMockStub;
+import org.folio.test.types.IntegrationTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+
+/**
+ * Covers the timer-execution retry policy end to end (MODSCHED-70, AC1-AC4).
+ *
+ * <p>Every timer here repeats once per minute but fires immediately, so exactly one execution happens inside the
+ * assertion window and the wire-call counts below are exact rather than lower bounds. The configured attempt cap
+ * for integration tests is in {@code application-it.yml}.</p>
+ */
+@EnableKeycloakTlsMode
+@IntegrationTest
+@Sql(scripts = "classpath:/sql/truncate-tables.sql", executionPhase = AFTER_TEST_METHOD)
+class TimerExecutionRetryIT extends BaseIntegrationTest {
+
+  /**
+   * The {@code retry-attempts} value configured in {@code application-it.yml}.
+   */
+  private static final int MAX_ATTEMPTS = 4;
+  private static final String JOB_GROUP = TENANT_ID + "#" + MODULE_NAME;
+
+  @Autowired private Scheduler scheduler;
+
+  @BeforeAll
+  static void beforeAll() {
+    setUpTenant();
+  }
+
+  @AfterAll
+  static void afterAll() {
+    removeTenant();
+  }
+
+  @AfterEach
+  void tearDown() throws SchedulerException {
+    scheduler.clear();
+  }
+
+  @Test
+  @WireMockStub(scripts = {
+    "/wiremock/stubs/retry-recovers-first-attempt.json",
+    "/wiremock/stubs/retry-recovers-later-attempts.json"})
+  @KeycloakRealms("/json/keycloak/test-realm.json")
+  void execute_positive_retriesAfterAuthorizationServiceFailure() throws Exception {
+    var timerId = createTimer("/test/retry-recovers");
+
+    // AC1 + AC2: the sidecar authorization failure is retried and the second call succeeds
+    awaitCallCount("/test/retry-recovers", 2);
+    pauseAndAwaitCompletion(timerId);
+  }
+
+  @Test
+  @WireMockStub("/wiremock/stubs/retry-always-fails.json")
+  @KeycloakRealms("/json/keycloak/test-realm.json")
+  void execute_negative_stopsAfterConfiguredRetriesAreExhausted() throws Exception {
+    var timerId = createTimer("/test/retry-exhausted");
+
+    // AC3: a permanently failing retryable response stops after the configured number of attempts
+    awaitStableCallCount("/test/retry-exhausted", MAX_ATTEMPTS, Duration.ofMillis(300));
+    pauseAndAwaitCompletion(timerId);
+  }
+
+  @Test
+  @WireMockStub("/wiremock/stubs/retry-non-retryable.json")
+  @KeycloakRealms("/json/keycloak/test-realm.json")
+  void execute_negative_doesNotRetryNonRetryableFailure() throws Exception {
+    var timerId = createTimer("/test/retry-non-retryable");
+
+    // AC4: generic 503 is not retryable. Stability beyond Retry-After also proves transport retries are disabled.
+    awaitStableCallCount("/test/retry-non-retryable", 1, Duration.ofMillis(1200));
+    pauseAndAwaitCompletion(timerId);
+  }
+
+  private UUID createTimer(String path) throws Exception {
+    var timerId = UUID.randomUUID();
+    var timerDescriptor = new TimerDescriptor()
+      .id(timerId)
+      .enabled(true)
+      .moduleId(MODULE_ID)
+      .routingEntry(new RoutingEntry()
+        .methods(List.of("POST"))
+        .pathPattern(path)
+        .delay("1")
+        .unit(MINUTE));
+
+    doPost("/scheduler/timers", timerDescriptor).andExpect(jsonPath("$.enabled", is(true)));
+    return timerId;
+  }
+
+  private void pauseAndAwaitCompletion(UUID timerId) throws SchedulerException {
+    scheduler.pauseTrigger(triggerKey(timerId.toString(), JOB_GROUP));
+    var jobKey = jobKey(timerId.toString(), JOB_GROUP);
+    await().atMost(TEN_SECONDS).pollInterval(ONE_HUNDRED_MILLISECONDS)
+      .untilAsserted(() -> assertThat(scheduler.getCurrentlyExecutingJobs())
+        .noneMatch(context -> context.getJobDetail().getKey().equals(jobKey)));
+  }
+
+  private static void awaitCallCount(String path, int expected) {
+    await().atMost(TEN_SECONDS).pollInterval(ONE_HUNDRED_MILLISECONDS)
+      .untilAsserted(() -> assertThat(timerCallCount(path)).isEqualTo(expected));
+  }
+
+  private static void awaitStableCallCount(String path, int expected, Duration stabilityWindow) {
+    awaitCallCount(path, expected);
+    await().during(stabilityWindow).atMost(TEN_SECONDS).pollInterval(ONE_HUNDRED_MILLISECONDS)
+      .untilAsserted(() -> assertThat(timerCallCount(path)).isEqualTo(expected));
+  }
+}

--- a/src/test/java/org/folio/scheduler/service/jobs/OkapiHttpRequestExecutorTest.java
+++ b/src/test/java/org/folio/scheduler/service/jobs/OkapiHttpRequestExecutorTest.java
@@ -1,6 +1,7 @@
 package org.folio.scheduler.service.jobs;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.time.Duration.ofMillis;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.folio.scheduler.support.TestConstants.TENANT_ID;
@@ -8,7 +9,9 @@ import static org.folio.scheduler.support.TestConstants.TIMER_UUID;
 import static org.folio.scheduler.support.TestConstants.USER_ID;
 import static org.folio.scheduler.support.TestConstants.USER_ID_UUID;
 import static org.folio.scheduler.support.TestConstants.USER_TOKEN;
+import static org.folio.scheduler.utils.TestUtils.OBJECT_MAPPER;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -28,7 +31,10 @@ import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.apache.logging.log4j.message.StringMapMessage;
+import org.folio.scheduler.configuration.TimerExecutionRetryConfiguration;
 import org.folio.scheduler.configuration.properties.OkapiConfigurationProperties;
+import org.folio.scheduler.configuration.properties.RetryConfigurationProperties;
+import org.folio.scheduler.configuration.properties.RetryConfigurationProperties.RetryProperties;
 import org.folio.scheduler.domain.dto.RoutingEntry;
 import org.folio.scheduler.domain.dto.TimerDescriptor;
 import org.folio.scheduler.domain.dto.TimerType;
@@ -47,7 +53,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.quartz.JobDetail;
@@ -55,6 +60,8 @@ import org.quartz.JobExecutionContext;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.ResourceAccessException;
 
 @UnitTest
@@ -67,7 +74,9 @@ class OkapiHttpRequestExecutorTest {
   private static final String MODULE_NAME = "mod-scheduler";
   private static final String SYSTEM_USER_ID = "99999999-9999-9999-9999-999999999999";
 
-  @InjectMocks private OkapiHttpRequestExecutor job;
+  private static final int RETRY_ATTEMPTS = 3;
+
+  private OkapiHttpRequestExecutor job;
   @Mock private OkapiClient okapiClient;
   @Mock private JobExecutionContext jobExecutionContext;
   @Mock private FolioModuleMetadata folioModuleMetadata;
@@ -87,6 +96,21 @@ class OkapiHttpRequestExecutorTest {
     logAppender.start();
     logger.addAppender(logAppender);
     logger.setLevel(Level.INFO);
+    job = newExecutor(RETRY_ATTEMPTS);
+  }
+
+  /**
+   * Builds the executor with the production retry assembly, only with negligible backoff so tests stay fast.
+   */
+  private OkapiHttpRequestExecutor newExecutor(int retryAttempts) {
+    var properties = new RetryConfigurationProperties();
+    properties.setConfig(Map.of("timer-execution", RetryProperties.of(ofMillis(1), ofMillis(2), retryAttempts, 2)));
+    var classifier = new TimerExecutionRetryClassifier(OBJECT_MAPPER);
+    var retryTemplate = new TimerExecutionRetryConfiguration()
+      .timerExecutionRetryTemplate(properties, classifier);
+
+    return new OkapiHttpRequestExecutor(okapiClient, folioModuleMetadata, schedulerTimerService,
+      okapiConfigurationProperties, userImpersonationService, systemUserService, retryTemplate, classifier);
   }
 
   @AfterEach
@@ -228,8 +252,8 @@ class OkapiHttpRequestExecutorTest {
     job.execute(jobExecutionContext);
 
     verify(okapiClient).doDelete(expectedUri, TEST_MODULE_ID);
-    assertHttpStatusFailureLog(assertSystemTimerEvent("timer.execution.failure", "DELETE", "/test-endpoint",
-      "test-endpoint"));
+    var event = assertSystemTimerEvent("timer.execution.failure", "DELETE", "/test-endpoint", "test-endpoint");
+    assertHttpStatusFailureLog(event);
     assertLoggedMessagesDoNotContain(USER_TOKEN, SYSTEM_USER_ID, "downstream-secret", "body-secret");
   }
 
@@ -249,9 +273,10 @@ class OkapiHttpRequestExecutorTest {
 
     job.execute(jobExecutionContext);
 
+    // a read timeout is deliberately not retried: the first request is most likely still running
     verify(okapiClient).doPost(expectedUri, TEST_MODULE_ID);
-    assertRestClientFailureLog(assertSystemTimerEvent("timer.execution.failure", "POST", "/test-endpoint",
-      "test-endpoint"));
+    var event = assertSystemTimerEvent("timer.execution.failure", "POST", "/test-endpoint", "test-endpoint");
+    assertRestClientFailureLog(event);
     assertLoggedMessagesDoNotContain(USER_TOKEN, SYSTEM_USER_ID, "transport-secret");
   }
 
@@ -274,6 +299,76 @@ class OkapiHttpRequestExecutorTest {
   }
 
   @Test
+  void execute_positive_retriesWithStructuredLogAfterTransientFailure() {
+    var re = new RoutingEntry().path("test-endpoint").methods(List.of("POST"));
+    var expectedUri = fromUriString("http://test-endpoint").build().toUri();
+    stubSystemTimer(re);
+    doThrow(serverError(HttpStatus.SERVICE_UNAVAILABLE, authorizationErrorBody())).doNothing()
+      .when(okapiClient).doPost(expectedUri, TEST_MODULE_ID);
+
+    job.execute(jobExecutionContext);
+
+    verify(okapiClient, times(2)).doPost(expectedUri, TEST_MODULE_ID);
+    verify(userImpersonationService).impersonate(TENANT_ID, SYSTEM_USER_ID);
+    assertSuccessLog(assertSystemTimerEvent("timer.execution.success", "POST", "/test-endpoint", "test-endpoint"));
+    assertThat(assertSystemTimerEvent("timer.execution.retry", "POST", "/test-endpoint", "test-endpoint"))
+      .containsEntry("outcome", "RETRY")
+      .containsEntry("retryNumber", 1)
+      .containsEntry("reason", "AUTHORIZATION_SERVICE_UNAVAILABLE");
+    assertLoggedMessagesDoNotContain("authorization-secret");
+  }
+
+  @Test
+  void execute_negative_doesNotRetryGenericServerFailure() {
+    var re = new RoutingEntry().path("test-endpoint").methods(List.of("POST"));
+    var expectedUri = fromUriString("http://test-endpoint").build().toUri();
+    stubSystemTimer(re);
+    doThrow(serverError(HttpStatus.SERVICE_UNAVAILABLE, "")).when(okapiClient)
+      .doPost(expectedUri, TEST_MODULE_ID);
+
+    job.execute(jobExecutionContext);
+
+    verify(okapiClient).doPost(expectedUri, TEST_MODULE_ID);
+    assertThat(assertSystemTimerEvent("timer.execution.failure", "POST", "/test-endpoint", "test-endpoint"))
+      .containsEntry("outcome", "FAILURE");
+    assertThat(logAppender.timerEvents()).noneMatch(event -> "timer.execution.retry".equals(event.get("event")));
+  }
+
+  @Test
+  void execute_negative_doesNotRetryForbiddenResponse() {
+    var re = new RoutingEntry().path("test-endpoint").methods(List.of("POST"));
+    var expectedUri = fromUriString("http://test-endpoint").build().toUri();
+    stubSystemTimer(re);
+    doThrow(clientError(HttpStatus.FORBIDDEN)).when(okapiClient).doPost(expectedUri, TEST_MODULE_ID);
+
+    job.execute(jobExecutionContext);
+
+    verify(okapiClient).doPost(expectedUri, TEST_MODULE_ID);
+    assertThat(logAppender.timerEvents()).noneMatch(event -> "timer.execution.retry".equals(event.get("event")));
+  }
+
+  @Test
+  void execute_negative_logsEachRetryAndOneFailureWhenRetriesAreExhausted() {
+    var re = new RoutingEntry().path("test-endpoint").methods(List.of("POST"));
+    var expectedUri = fromUriString("http://test-endpoint").build().toUri();
+    stubSystemTimer(re);
+    doThrow(serverError(HttpStatus.SERVICE_UNAVAILABLE, authorizationErrorBody())).when(okapiClient)
+      .doPost(expectedUri, TEST_MODULE_ID);
+
+    job.execute(jobExecutionContext);
+
+    verify(okapiClient, times(RETRY_ATTEMPTS)).doPost(expectedUri, TEST_MODULE_ID);
+    assertThat(logAppender.timerEvents())
+      .filteredOn(event -> "timer.execution.retry".equals(event.get("event")))
+      .extracting(event -> event.get("retryNumber"))
+      .containsExactly(1, 2);
+    assertThat(logAppender.timerEvents())
+      .filteredOn(event -> "timer.execution.failure".equals(event.get("event")))
+      .singleElement()
+      .satisfies(event -> assertThat(event).containsEntry("outcome", "FAILURE"));
+  }
+
+  @Test
   void execute_negative_timerDescriptorNotFound() {
     when(folioModuleMetadata.getModuleName()).thenReturn(MODULE_NAME);
     when(okapiConfigurationProperties.getUrl()).thenReturn(OKAPI_URL);
@@ -286,6 +381,35 @@ class OkapiHttpRequestExecutorTest {
       .isInstanceOf(EntityNotFoundException.class);
 
     verifyNoInteractions(okapiClient);
+  }
+
+  private void stubSystemTimer(RoutingEntry re) {
+    when(folioModuleMetadata.getModuleName()).thenReturn(MODULE_NAME);
+    when(okapiConfigurationProperties.getUrl()).thenReturn(OKAPI_URL);
+    when(jobExecutionContext.getJobDetail()).thenReturn(systemJobDetail());
+    when(systemUserService.findSystemUserId(TENANT_ID)).thenReturn(SYSTEM_USER_ID);
+    when(userImpersonationService.impersonate(TENANT_ID, SYSTEM_USER_ID)).thenReturn(USER_TOKEN);
+    when(schedulerTimerService.getById(TIMER_UUID)).thenReturn(systemTimerDescriptor(re));
+  }
+
+  private static HttpStatusCodeException clientError(HttpStatus status) {
+    return clientError(status, "");
+  }
+
+  private static HttpStatusCodeException clientError(HttpStatus status, String body) {
+    return HttpClientErrorException.create(status, status.getReasonPhrase(), new HttpHeaders(), body.getBytes(UTF_8),
+      UTF_8);
+  }
+
+  private static HttpStatusCodeException serverError(HttpStatus status, String body) {
+    return HttpServerErrorException.create(status, status.getReasonPhrase(), new HttpHeaders(), body.getBytes(UTF_8),
+      UTF_8);
+  }
+
+  private static String authorizationErrorBody() {
+    return """
+      {"errors":[{"code":"authorization_error","message":"authorization-secret"}],"total_records":1}
+      """;
   }
 
   private static JobDetail systemJobDetail() {

--- a/src/test/java/org/folio/scheduler/service/jobs/TimerExecutionRetryClassifierTest.java
+++ b/src/test/java/org/folio/scheduler/service/jobs/TimerExecutionRetryClassifierTest.java
@@ -1,0 +1,148 @@
+package org.folio.scheduler.service.jobs;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.scheduler.utils.TestUtils.OBJECT_MAPPER;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.util.stream.Stream;
+import javax.net.ssl.SSLHandshakeException;
+import org.apache.hc.client5.http.ConnectTimeoutException;
+import org.apache.hc.core5.http.ConnectionRequestTimeoutException;
+import org.folio.test.types.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClientException;
+
+@UnitTest
+class TimerExecutionRetryClassifierTest {
+
+  private final TimerExecutionRetryClassifier classifier = new TimerExecutionRetryClassifier(OBJECT_MAPPER);
+
+  @ParameterizedTest
+  @ValueSource(ints = {500, 502, 503, 504, 599})
+  void isRetryable_positive_returnsTrueForAuthorizationErrorServerFailure(int status) {
+    var responseBody = """
+      {"errors":[{"type":"AuthorizationException","code":"authorization_error","message":"Unavailable"}],
+       "total_records":1}
+      """;
+
+    assertThat(classifier.isRetryable(serverError(status, responseBody))).isTrue();
+  }
+
+  @Test
+  void isRetryable_positive_returnsTrueWhenRetryCodeIsNotFirstInErrors() {
+    var responseBody = """
+      {"errors":[{"code":"service_unavailable"},{"code":"authorization_error"}],"total_records":2}
+      """;
+
+    assertThat(classifier.isRetryable(serverError(503, responseBody))).isTrue();
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {400, 401, 403, 404, 408, 429})
+  void isRetryable_negative_returnsFalseForClientErrors(int status) {
+    assertThat(classifier.isRetryable(clientError(status, ""))).isFalse();
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {500, 502, 503, 504, 599})
+  void isRetryable_negative_returnsFalseForGenericServerErrors(int status) {
+    assertThat(classifier.isRetryable(serverError(status, ""))).isFalse();
+  }
+
+  @Test
+  void isRetryable_negative_returnsFalseForTenantNotEnabledBadRequest() {
+    var responseBody = """
+      {"errors":[{"type":"TenantNotEnabledException","code":"tenant_not_enabled","message":"Tenant is disabled"}],
+       "total_records":1}
+      """;
+
+    assertThat(classifier.isRetryable(clientError(400, responseBody))).isFalse();
+  }
+
+  @Test
+  void isRetryable_negative_returnsFalseForOtherServerErrorCode() {
+    var responseBody = """
+      {"errors":[{"code":"service_unavailable"}],"total_records":1}
+      """;
+
+    assertThat(classifier.isRetryable(serverError(503, responseBody))).isFalse();
+  }
+
+  @Test
+  void isRetryable_negative_returnsFalseForMalformedResponseBody() {
+    assertThat(classifier.isRetryable(serverError(503, "not-json"))).isFalse();
+  }
+
+  @ParameterizedTest
+  @MethodSource("retryableTransportFailures")
+  void isRetryable_positive_returnsTrueForTransportFailureBeforeRequestIsSent(IOException cause) {
+    assertThat(classifier.isRetryable(transportFailure(cause))).isTrue();
+  }
+
+  private static Stream<IOException> retryableTransportFailures() {
+    return Stream.of(
+      new ConnectTimeoutException("connect timed out"),
+      new ConnectException("Connection refused"),
+      new ConnectionRequestTimeoutException("connection pool timed out"));
+  }
+
+  /**
+   * A read timeout, an unknown host and a TLS failure are all {@link IOException}s that must stay non-retryable.
+   */
+  @ParameterizedTest
+  @MethodSource("nonRetryableTransportFailures")
+  void isRetryable_negative_returnsFalseForOtherTransportFailure(IOException cause) {
+    assertThat(classifier.isRetryable(transportFailure(cause))).isFalse();
+  }
+
+  private static Stream<IOException> nonRetryableTransportFailures() {
+    return Stream.of(
+      new IOException("broken pipe"),
+      new SocketTimeoutException("Read timed out"),
+      new UnknownHostException("no-such-host"),
+      new SSLHandshakeException("handshake failed"));
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @MethodSource("unrecognizedFailures")
+  void isRetryable_negative_returnsFalseForUnrecognizedFailure(Throwable throwable) {
+    assertThat(classifier.isRetryable(throwable)).isFalse();
+  }
+
+  private static Stream<Throwable> unrecognizedFailures() {
+    return Stream.of(
+      new RestClientException("no cause"),
+      new IllegalStateException("pre-flight failure"));
+  }
+
+  private static RestClientException clientError(int status, String responseBody) {
+    var statusText = HttpStatus.resolve(status) == null ? "Custom" : HttpStatus.valueOf(status).getReasonPhrase();
+    return HttpClientErrorException.create(
+      HttpStatusCode.valueOf(status), statusText, new HttpHeaders(), responseBody.getBytes(UTF_8), UTF_8);
+  }
+
+  private static RestClientException serverError(int status, String responseBody) {
+    var statusText = HttpStatus.resolve(status) == null ? "Custom" : HttpStatus.valueOf(status).getReasonPhrase();
+    return HttpServerErrorException.create(
+      HttpStatusCode.valueOf(status), statusText, new HttpHeaders(), responseBody.getBytes(UTF_8), UTF_8);
+  }
+
+  private static RestClientException transportFailure(IOException cause) {
+    return new ResourceAccessException("I/O error on POST request", cause);
+  }
+}

--- a/src/test/java/org/folio/scheduler/support/base/BaseIntegrationTest.java
+++ b/src/test/java/org/folio/scheduler/support/base/BaseIntegrationTest.java
@@ -169,6 +169,16 @@ public abstract class BaseIntegrationTest extends BaseBackendIntegrationTest {
     kafkaAdmin.createOrModifyTopics(new NewTopic(topicName, 1, (short) 1));
   }
 
+  /**
+   * Exact number of timer POSTs WireMock has seen for the given path.
+   */
+  protected static int timerCallCount(String urlPath) {
+    return wmAdminClient.requestCount(RequestCriteria.builder()
+      .urlPath(urlPath)
+      .method(HttpMethod.POST)
+      .build());
+  }
+
   protected static void verifyTimerRequestCallsCount() {
     var count = wmAdminClient.requestCount(RequestCriteria.builder()
       .urlPath("/test")

--- a/src/test/resources/application-it.yml
+++ b/src/test/resources/application-it.yml
@@ -52,6 +52,11 @@ application:
         max-delay: 250ms
         retry-attempts: 3
         retry-multiplier: 1.5
+      timer-execution:
+        retry-delay: 50ms
+        max-delay: 100ms
+        retry-attempts: 4
+        retry-multiplier: 2
   keycloak:
     admin:
       client-id: folio-backend-admin-client

--- a/src/test/resources/wiremock/stubs/retry-always-fails.json
+++ b/src/test/resources/wiremock/stubs/retry-always-fails.json
@@ -1,0 +1,22 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPattern": "/test/retry-exhausted"
+  },
+  "response": {
+    "status": 503,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "errors": [
+        {
+          "type": "AuthorizationException",
+          "code": "authorization_error",
+          "message": "Authorization service is unavailable"
+        }
+      ],
+      "total_records": 1
+    }
+  }
+}

--- a/src/test/resources/wiremock/stubs/retry-non-retryable.json
+++ b/src/test/resources/wiremock/stubs/retry-non-retryable.json
@@ -1,0 +1,23 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPattern": "/test/retry-non-retryable"
+  },
+  "response": {
+    "status": 503,
+    "headers": {
+      "Content-Type": "application/json",
+      "Retry-After": "1"
+    },
+    "jsonBody": {
+      "errors": [
+        {
+          "type": "ServiceUnavailableException",
+          "code": "service_unavailable",
+          "message": "Generic service failure"
+        }
+      ],
+      "total_records": 1
+    }
+  }
+}

--- a/src/test/resources/wiremock/stubs/retry-recovers-first-attempt.json
+++ b/src/test/resources/wiremock/stubs/retry-recovers-first-attempt.json
@@ -1,0 +1,25 @@
+{
+  "scenarioName": "timer-retry-recovers",
+  "requiredScenarioState": "Started",
+  "newScenarioState": "downstream-recovered",
+  "request": {
+    "method": "POST",
+    "urlPattern": "/test/retry-recovers"
+  },
+  "response": {
+    "status": 503,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "errors": [
+        {
+          "type": "AuthorizationException",
+          "code": "authorization_error",
+          "message": "Authorization service is unavailable"
+        }
+      ],
+      "total_records": 1
+    }
+  }
+}

--- a/src/test/resources/wiremock/stubs/retry-recovers-later-attempts.json
+++ b/src/test/resources/wiremock/stubs/retry-recovers-later-attempts.json
@@ -1,0 +1,17 @@
+{
+  "scenarioName": "timer-retry-recovers",
+  "requiredScenarioState": "downstream-recovered",
+  "request": {
+    "method": "POST",
+    "urlPattern": "/test/retry-recovers"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "message": "success!"
+    }
+  }
+}

--- a/src/test/resources/wiremock/stubs/slow-timer-endpoint.json
+++ b/src/test/resources/wiremock/stubs/slow-timer-endpoint.json
@@ -1,0 +1,16 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPattern": "/test/slow-timer"
+  },
+  "response": {
+    "status": 200,
+    "fixedDelayMilliseconds": 3000,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "message": "success!"
+    }
+  }
+}


### PR DESCRIPTION
### **Purpose**

Scheduled timer delivery needs to recover from selected transient failures without duplicating downstream work. This adds retry behavior and prevents a timer from overlapping its own active execution.

https://folio-org.atlassian.net/browse/MODSCHED-70

### **Approach**

- Added a timer-execution retry template with configurable exponential backoff and an allowlist for retryable authorization and connection failures.
- Disabled HTTP client transport retries so timer delivery uses only the explicit retry policy.
- Applied Quartz execution serialization to timer jobs and added structured retry logging.
- Added unit and integration coverage for retry outcomes and concurrent timer execution.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.